### PR TITLE
[GHO-25] Add translations to the CD header and footer

### DIFF
--- a/html/themes/custom/common_design_subtheme/README.md
+++ b/html/themes/custom/common_design_subtheme/README.md
@@ -128,6 +128,18 @@ The list below contains additions to the default common design subtheme:
 - Header: [OCHA services](templates/cd/cd-header/cd-ocha.html.twig)
 - Footer: [Social menu](templates/cd/cd-footer/cd-social-menu.html.twig)
 
+Translations
+------------
+
+The following templates are overridden to allow for translation of the texts.
+
+**TODO:** Once validated, the changes could/should be pushed upstream in the
+`common_design` theme.
+
+- [cd-footer/cd-copyright.html.twig](templates/cd/cd-footer/cd-copyright.html.twig)
+- [cd-footer/cd-mandate.html.twig](templates/cd/cd-footer/cd-mandate.html.twig)
+- [cd-header/cd-ocha.html.twig](templates/cd/cd-header/cd-ocha.html.twig)
+
 ---
 
 ## OCHA Common Design sub theme for Drupal 8

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-copyright.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-copyright.html.twig
@@ -1,0 +1,11 @@
+<div class="cd-footer__section cd-footer__section--copyright">
+  <div class="cd-footer-copyright">
+    <span class="cd-footer-copyright__text">{{ 'Except where otherwise noted, content on this site is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0</a> International license.'|t }}</span>
+    <a class="cd-footer-copyright__link" href="https://creativecommons.org/licenses/by/4.0/">
+      <span class="visually-hidden">{{ 'Creative Commons BY 4.0'|t }}</span>
+      <svg class="cd-icon cd-icon--cc" width="32" height="32">
+        <use xlink:href="#cd-icon--creative-commons"></use>
+      </svg>
+    </a>
+  </div>
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-mandate.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-footer/cd-mandate.html.twig
@@ -1,0 +1,11 @@
+<div class="cd-footer__section cd-footer__section--mandate">
+  <div class="cd-mandate">
+    <span class="cd-mandate__heading">{{ 'Service provided by'|t }}</span>
+    <span class="cd-mandate__logo">
+      <span class="visually-hidden">{{ 'UN-OCHA'|t }}</span>
+    </span>
+    <span class="cd-mandate__text">
+    {{ 'OCHA coordinates the global emergency response to save lives and protect people in humanitarian crises. We advocate for effective and principled humanitarian action by all, for all.'|t }}
+    </span>
+  </div>
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-ocha.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/cd/cd-header/cd-ocha.html.twig
@@ -1,3 +1,46 @@
+<div class="cd-ocha">
+
+  {# Dropdown toggle is created with javascript #}
+
+  <div class="cd-global-header__dropdown cd-ocha-dropdown cd-dropdown" role="menu" id="cd-ocha-dropdown" aria-label="OCHA Services" data-cd-toggable="OCHA Services" data-cd-hidden="true" data-cd-icon="arrow-down" data-cd-logo="ocha-logo" data-cd-component="cd-ocha">
+    <div class="cd-ocha-dropdown__inner">
+      <div class="cd-ocha-dropdown__section">
+        <p class="cd-ocha-dropdown__heading">{{ 'Related Platforms'|t }}</p>
+        <ul class="cd-ocha-dropdown__list">
+          {% block related_platforms %}
+          <li class="cd-ocha-dropdown__link"><a href="https://interagencystandingcommittee.org">{{ 'Inter-Agency Standing Committee'|t }}</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://unocha.org/">{{ 'OCHA website'|t }}</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://reliefweb.int/">{{ 'ReliefWeb'|t }}</a></li>
+          {% endblock %}
+        </ul>
+      </div>
+      <div class="cd-ocha-dropdown__section">
+        <p class="cd-ocha-dropdown__heading">{{ 'Other OCHA Services'|t }}</p>
+        <ul class="cd-ocha-dropdown__list">
+          {% block other_services_first %}
+          <li class="cd-ocha-dropdown__link"><a href="https://data.humdata.org/">{{ 'Humanitarian Data Exchange'|t }}</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://humanitarian.id/">{{ 'Humanitarian ID'|t }}</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://humanitarianresponse.info/">{{ 'Humanitarian Response'|t }}</a></li>
+          {% endblock %}
+        </ul>
+      </div>
+      <div class="cd-ocha-dropdown__section">
+        <p class="cd-ocha-dropdown__heading" aria-hidden="true">&nbsp;</p>
+        <ul class="cd-ocha-dropdown__list">
+          {% block other_services_second %}
+          <li class="cd-ocha-dropdown__link"><a href="https://fts.unocha.org/">{{ 'Financial Tracking'|t }} Service</a></li>
+          <li class="cd-ocha-dropdown__link"><a href="https://vosocc.unocha.org/">{{ 'Virtual OSOCC'|t }}</a></li>
+          {% endblock %}
+        </ul>
+      </div>
+      <div class="cd-ocha-dropdown__section">
+        <a class="cd-ocha-dropdown__see-all" href="https://www.unocha.org/ocha-digital-services" target="_blank" rel="noopener">{{ 'See all'|t }}</a>
+      </div>
+    </div>
+  </div>
+</div>
+{# @todo replace the above with the following once the translation changes are
+   added to the common_design theme.
 {% embed '@common_design/cd/cd-header/cd-ocha.html.twig' %}
 
   {% block related_platforms %}
@@ -18,3 +61,4 @@
   {% endblock %}
 
 {% endembed %}
+#}


### PR DESCRIPTION
Ticket: https://humanitarian.atlassian.net/browse/GHO-25

This makes the texts in the header and footer translatable and should probably be moved to the `common_design` theme later on.