### PR TITLE
[GHO-16] Add photo gallery component

### DIFF
--- a/config/core.entity_form_display.paragraph.photo_gallery.default.yml
+++ b/config/core.entity_form_display.paragraph.photo_gallery.default.yml
@@ -1,0 +1,51 @@
+uuid: 7c8d36fa-fed5-414b-b5e9-b09ec7e81898
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.photo_gallery.field_caption
+    - field.field.paragraph.photo_gallery.field_credits
+    - field.field.paragraph.photo_gallery.field_location
+    - field.field.paragraph.photo_gallery.field_photos
+    - paragraphs.paragraphs_type.photo_gallery
+  module:
+    - media_library
+id: paragraph.photo_gallery.default
+targetEntityType: paragraph
+bundle: photo_gallery
+mode: default
+content:
+  field_caption:
+    weight: 2
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_credits:
+    weight: 3
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_location:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_photos:
+    type: media_library_widget
+    weight: 0
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.media.image.half_width.yml
+++ b/config/core.entity_view_display.media.image.half_width.yml
@@ -1,0 +1,36 @@
+uuid: d64c1022-e612-48be-b23e-089900ddf3e6
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.half_width
+    - field.field.media.image.field_media_image
+    - media.type.image
+    - responsive_image.styles.half_width
+  module:
+    - layout_builder
+    - responsive_image
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: media.image.half_width
+targetEntityType: media
+bundle: image
+mode: half_width
+content:
+  field_media_image:
+    label: hidden
+    weight: 0
+    settings:
+      responsive_image_style: half_width
+      image_link: ''
+    third_party_settings: {  }
+    type: responsive_image
+    region: content
+hidden:
+  created: true
+  langcode: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/config/core.entity_view_display.paragraph.photo_gallery.default.yml
+++ b/config/core.entity_view_display.paragraph.photo_gallery.default.yml
@@ -1,0 +1,48 @@
+uuid: 3c1e776b-d902-4fea-a464-ab28d206d3c0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.photo_gallery.field_caption
+    - field.field.paragraph.photo_gallery.field_credits
+    - field.field.paragraph.photo_gallery.field_location
+    - field.field.paragraph.photo_gallery.field_photos
+    - paragraphs.paragraphs_type.photo_gallery
+id: paragraph.photo_gallery.default
+targetEntityType: paragraph
+bundle: photo_gallery
+mode: default
+content:
+  field_caption:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_credits:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_location:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_photos:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: thumbnail_medium
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_view_display.paragraph.photo_gallery.single_column.yml
+++ b/config/core.entity_view_display.paragraph.photo_gallery.single_column.yml
@@ -1,0 +1,55 @@
+uuid: 7b925fd7-325f-4feb-89f2-53e5b3d809d6
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.single_column
+    - field.field.paragraph.photo_gallery.field_caption
+    - field.field.paragraph.photo_gallery.field_credits
+    - field.field.paragraph.photo_gallery.field_location
+    - field.field.paragraph.photo_gallery.field_photos
+    - paragraphs.paragraphs_type.photo_gallery
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.photo_gallery.single_column
+targetEntityType: paragraph
+bundle: photo_gallery
+mode: single_column
+content:
+  field_caption:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_credits:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_location:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_photos:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: full_width
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_view_display.paragraph.photo_gallery.two_columns.yml
+++ b/config/core.entity_view_display.paragraph.photo_gallery.two_columns.yml
@@ -1,0 +1,55 @@
+uuid: 5aa483f9-1f2f-4ef9-8d1a-ce79915e5756
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.two_columns
+    - field.field.paragraph.photo_gallery.field_caption
+    - field.field.paragraph.photo_gallery.field_credits
+    - field.field.paragraph.photo_gallery.field_location
+    - field.field.paragraph.photo_gallery.field_photos
+    - paragraphs.paragraphs_type.photo_gallery
+  module:
+    - layout_builder
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: paragraph.photo_gallery.two_columns
+targetEntityType: paragraph
+bundle: photo_gallery
+mode: two_columns
+content:
+  field_caption:
+    weight: 2
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_credits:
+    weight: 3
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_location:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_photos:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: half_width
+      link: false
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/config/core.entity_view_mode.media.half_width.yml
+++ b/config/core.entity_view_mode.media.half_width.yml
@@ -1,0 +1,10 @@
+uuid: af7817a4-6694-4911-b599-3cde7be65eb4
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.half_width
+label: 'Half Width'
+targetEntityType: media
+cache: true

--- a/config/core.entity_view_mode.paragraph.single_column.yml
+++ b/config/core.entity_view_mode.paragraph.single_column.yml
@@ -1,0 +1,10 @@
+uuid: c2ecbc97-014e-4e5d-bc7d-f150dcc58576
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.single_column
+label: 'Single Column'
+targetEntityType: paragraph
+cache: true

--- a/config/core.entity_view_mode.paragraph.two_columns.yml
+++ b/config/core.entity_view_mode.paragraph.two_columns.yml
@@ -1,0 +1,10 @@
+uuid: 32d2ced5-23cf-47a7-955e-f22abd90b885
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.two_columns
+label: 'Two Columns'
+targetEntityType: paragraph
+cache: true

--- a/config/field.field.node.article.field_paragraphs.yml
+++ b/config/field.field.node.article.field_paragraphs.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_paragraphs
     - node.type.article
     - paragraphs.paragraphs_type.layout
+    - paragraphs.paragraphs_type.photo_gallery
     - paragraphs.paragraphs_type.text
   module:
     - entity_reference_revisions
@@ -26,6 +27,7 @@ settings:
     target_bundles:
       layout: layout
       text: text
+      photo_gallery: photo_gallery
     target_bundles_drag_drop:
       image:
         weight: 6
@@ -39,6 +41,9 @@ settings:
       page_title:
         weight: 9
         enabled: false
+      photo_gallery:
+        enabled: true
+        weight: 11
       text:
         enabled: true
         weight: 10

--- a/config/field.field.paragraph.photo_gallery.field_caption.yml
+++ b/config/field.field.paragraph.photo_gallery.field_caption.yml
@@ -1,0 +1,19 @@
+uuid: aad4659e-603b-44b0-a075-895f1b006bba
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_caption
+    - paragraphs.paragraphs_type.photo_gallery
+id: paragraph.photo_gallery.field_caption
+field_name: field_caption
+entity_type: paragraph
+bundle: photo_gallery
+label: Caption
+description: 'Text describing the photos.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/field.field.paragraph.photo_gallery.field_credits.yml
+++ b/config/field.field.paragraph.photo_gallery.field_credits.yml
@@ -1,0 +1,19 @@
+uuid: 167c0ac0-118e-47d4-84df-9934bdf55d10
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_credits
+    - paragraphs.paragraphs_type.photo_gallery
+id: paragraph.photo_gallery.field_credits
+field_name: field_credits
+entity_type: paragraph
+bundle: photo_gallery
+label: Credits
+description: 'Credits for the photos in the form <em>Photographer/Organization</em>. Ex: <em>Jane Doe/OCHA</em>'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.photo_gallery.field_location.yml
+++ b/config/field.field.paragraph.photo_gallery.field_location.yml
@@ -1,0 +1,19 @@
+uuid: fef72aae-1307-44e6-81a2-f7f0e0b04e03
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_location
+    - paragraphs.paragraphs_type.photo_gallery
+id: paragraph.photo_gallery.field_location
+field_name: field_location
+entity_type: paragraph
+bundle: photo_gallery
+label: Location
+description: 'Location in the form <em>Location, Country</em>. Ex: <em>Mbuji-Mayi, RDC</em>.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.photo_gallery.field_photos.yml
+++ b/config/field.field.paragraph.photo_gallery.field_photos.yml
@@ -1,0 +1,28 @@
+uuid: 9e298b66-c6d0-4728-b8fd-64c246ae18f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_photos
+    - media.type.image
+    - paragraphs.paragraphs_type.photo_gallery
+id: paragraph.photo_gallery.field_photos
+field_name: field_photos
+entity_type: paragraph
+bundle: photo_gallery
+label: Photos
+description: 'Up to 4 photos.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.storage.paragraph.field_caption.yml
+++ b/config/field.storage.paragraph.field_caption.yml
@@ -1,0 +1,19 @@
+uuid: d1cfd676-5682-4a71-9429-388617f51c33
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_caption
+field_name: field_caption
+entity_type: paragraph
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_credits.yml
+++ b/config/field.storage.paragraph.field_credits.yml
@@ -1,0 +1,21 @@
+uuid: c81e63c5-0677-4a8b-b686-c8eb21db146e
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_credits
+field_name: field_credits
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_location.yml
+++ b/config/field.storage.paragraph.field_location.yml
@@ -1,0 +1,21 @@
+uuid: e93365b5-64cf-4a85-a433-6f8c89f26980
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_location
+field_name: field_location
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_photos.yml
+++ b/config/field.storage.paragraph.field_photos.yml
@@ -1,0 +1,20 @@
+uuid: b7a449c0-c805-40d5-8e31-9cd8f9b4026d
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - paragraphs
+id: paragraph.field_photos
+field_name: field_photos
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 4
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.photo_gallery.yml
+++ b/config/paragraphs.paragraphs_type.photo_gallery.yml
@@ -1,0 +1,26 @@
+uuid: c5e5598e-d4e8-4eb7-a97a-79a1569b4030
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs_viewmode
+id: photo_gallery
+label: 'Photo Gallery'
+icon_uuid: null
+icon_default: null
+description: 'A photo gallery with up to 4 images.'
+behavior_plugins:
+  paragraphs_viewmode_behavior:
+    enabled: true
+    override_mode: default
+    override_available:
+      single_column: single_column
+      two_columns: two_columns
+      default: '0'
+      hero_image: '0'
+      link_with_background_image_medium: '0'
+      link_with_background_image_small: '0'
+      linked_image_medium: '0'
+      linked_image_small: '0'
+      preview: '0'
+    override_default: single_column

--- a/config/responsive_image.styles.half_width.yml
+++ b/config/responsive_image.styles.half_width.yml
@@ -1,0 +1,48 @@
+uuid: 47b99a66-c3ef-40fe-be9a-74e017155989
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.desktop_x1
+    - image.style.desktop_x2
+    - image.style.hero_tablet_x1
+    - image.style.mobile_x1
+    - image.style.mobile_x2
+    - image.style.tablet_x2
+  theme:
+    - common_design
+id: half_width
+label: 'Half Width'
+image_style_mappings:
+  -
+    breakpoint_id: common_design.md
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: desktop_x1
+  -
+    breakpoint_id: common_design.md
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: desktop_x2
+  -
+    breakpoint_id: common_design.sm
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: hero_tablet_x1
+  -
+    breakpoint_id: common_design.sm
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: tablet_x2
+  -
+    breakpoint_id: common_design.xs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: mobile_x1
+  -
+    breakpoint_id: common_design.xs
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: mobile_x2
+breakpoint_group: common_design
+fallback_image_style: desktop_x1

--- a/html/themes/custom/common_design_subtheme/README.md
+++ b/html/themes/custom/common_design_subtheme/README.md
@@ -73,6 +73,10 @@ The list below contains additions to the default common design subtheme:
 
   Styling for the hero image (paragraph) displayed on public and private pages.
 
+- [components/gho-photo-gallery](components/gho-photo-gallery):
+
+  Styling for the photo gallery paragraphs in articles.
+
 **Layouts**
 
 - [layouts/twocol_section](layouts/twocol_section):

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -8,3 +8,8 @@ gho-hero-image:
   css:
     theme:
       components/gho-hero-image/gho-hero-image.css: {}
+
+gho-photo-gallery:
+  css:
+    theme:
+      components/gho-photo-gallery/gho-photo-gallery.css: {}

--- a/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/README.md
@@ -1,0 +1,7 @@
+Global Humanitarian Overview - Photo Gallery Component
+======================================================
+
+Styling for the photo gallery component which can be a single column or a two
+columns grid with up to 4 photos.
+
+The gallery also has a "location", a caption and credits.

--- a/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/gho-photo-gallery.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/gho-photo-gallery.css
@@ -1,0 +1,50 @@
+/**
+ * Base photo gallery.
+ */
+.gho-photo-gallery .field--name-field-photos {
+  /* Compensate for the padding of the photos */
+  margin: 0 -0.5rem;
+}
+.gho-photo-gallery .field--name-field-photos > .field__item {
+  padding: 0.5rem;
+}
+.gho-photo-gallery .field--name-field-location {
+  font-weight: bold;
+}
+.gho-photo-gallery .field--name-field-caption,
+.gho-photo-gallery .field--name-field-caption * {
+  display: inline;
+}
+.gho-photo-gallery .field--name-field-credits,
+.gho-photo-gallery .field--name-field-credits * {
+  display: inline;
+  font-style: italic;
+}
+
+/**
+ * Single column gallery.
+ *
+ * In this mode, the images (responsive) span the entire width of the pages's
+ * content region.
+ */
+.gho-photo-gallery--single-column {
+  /* @todo remove if unnecessary. */
+}
+
+/**
+ * Two columns gallery.
+ *
+ * In this mode, the images (responsive) span the half of the width the pages's
+ * content region on desktop and the entire width like the single column, on
+ * smaller screens.
+ */
+@media screen and (min-width: 768px) {
+  .gho-photo-gallery--two-columns .field--name-field-photos {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+  }
+  .gho-photo-gallery--two-columns .field--name-field-photos > .field__item {
+    flex: 0 0 50%;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--photo-gallery--single-column.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--photo-gallery--single-column.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Theme implementation for a photo gallery paragraph with a single column.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.a
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-photo-gallery') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-photo-gallery',
+    'gho-photo-gallery--single-column',
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--photo-gallery--two-columns.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--photo-gallery--two-columns.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Theme implementation for a photo gallery paragraph with two columns.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.a
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-photo-gallery') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-photo-gallery',
+    'gho-photo-gallery--two-columns',
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Ticket: https://humanitarian.atlassian.net/browse/GHO-16

This adds a "Photo Gallery" paragraph type and its dependencies: image styles, responsive image styles, view modes.

This paragraph type has the following fields:
- Photos (media reference, up to 4 images)
- Location (free form text to enter things like `Paris, France`)
- Caption (free form text to describe the images in the gallery)
- Credits (free form text to enter things like `Jane Doe/OCHA`)

The paragraph has 2 view modes: single column or two columns that becomes identical to the single column on smaller screens < 768px.

This also adds a CSS component in the subtheme: `components/gho-photo-gallery` with basic css rules to refine. There are templates for each view mode in `templates/paragaphs`.

This also alter the field_paragraphs of the article to allow the use of the photo gallery paragraph type.

This is only configuration and can be enabled via `drush cim`.