### PR TITLE
[GHO-37] Enable background only bleeding

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-bleed/gho-bleed.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-bleed/gho-bleed.css
@@ -45,9 +45,10 @@
 .gho-bleed--background-only:before {
   content: "";
   position: absolute;
-  top: 0;
   left: 0;
-  width: 100%;
+  right: 0;
+  top: 0;
+  bottom: 0;
   height: 100%;
   margin-left: calc(50% - 50vw + var(--gho-bleed-scrollbar-width) / 2);
   margin-right: calc(50% - 50vw + var(--gho-bleed-scrollbar-width) / 2);


### PR DESCRIPTION
Ticket: GHO-37

Add a class to have only the background bleed while keeping the content contained in the main area. This is done by use a `before` pseudo-element. This is notably for the the field stories.