### PR TITLE
GHO-11: add the source link

### DIFF
--- a/config/core.entity_form_display.paragraph.bottom_figure_row.default.yml
+++ b/config/core.entity_form_display.paragraph.bottom_figure_row.default.yml
@@ -4,9 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.bottom_figure_row.field_bottom_figures
+    - field.field.paragraph.bottom_figure_row.field_dataset
     - paragraphs.paragraphs_type.bottom_figure_row
   module:
     - double_field
+    - link
 id: paragraph.bottom_figure_row.default
 targetEntityType: paragraph
 bundle: bottom_figure_row
@@ -38,6 +40,14 @@ content:
       inline: false
     third_party_settings: {  }
     type: double_field
+    region: content
+  field_dataset:
+    weight: 1
+    settings:
+      placeholder_url: 'https://example.com/link-to-data'
+      placeholder_title: 'Ex: Office for the Coordination of Humanitarian Affairs'
+    third_party_settings: {  }
+    type: link_default
     region: content
 hidden:
   created: true

--- a/config/core.entity_view_display.paragraph.bottom_figure_row.default.yml
+++ b/config/core.entity_view_display.paragraph.bottom_figure_row.default.yml
@@ -4,9 +4,11 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.bottom_figure_row.field_bottom_figures
+    - field.field.paragraph.bottom_figure_row.field_dataset
     - paragraphs.paragraphs_type.bottom_figure_row
   module:
     - double_field
+    - link
 id: paragraph.bottom_figure_row.default
 targetEntityType: paragraph
 bundle: bottom_figure_row
@@ -37,5 +39,17 @@ content:
       inline: false
     third_party_settings: {  }
     type: double_field_unformatted_list
+    region: content
+  field_dataset:
+    weight: 1
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    type: link
     region: content
 hidden: {  }

--- a/config/field.field.paragraph.bottom_figure_row.field_dataset.yml
+++ b/config/field.field.paragraph.bottom_figure_row.field_dataset.yml
@@ -1,0 +1,23 @@
+uuid: b70baaa3-9477-44e6-89ac-990349cf0906
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_dataset
+    - paragraphs.paragraphs_type.bottom_figure_row
+  module:
+    - link
+id: paragraph.bottom_figure_row.field_dataset
+field_name: field_dataset
+entity_type: paragraph
+bundle: bottom_figure_row
+label: Source
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 2
+field_type: link

--- a/config/field.storage.paragraph.field_bottom_figures.yml
+++ b/config/field.storage.paragraph.field_bottom_figures.yml
@@ -25,7 +25,7 @@ settings:
       datetime_type: datetime
 module: double_field
 locked: false
-cardinality: 4
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/field.storage.paragraph.field_dataset.yml
+++ b/config/field.storage.paragraph.field_dataset.yml
@@ -1,0 +1,19 @@
+uuid: ff9dd195-d123-45a5-bef0-674770eab358
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_dataset
+field_name: field_dataset
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
@@ -11,8 +11,8 @@
 .gho-bottom-figure-row .field__items > .field__item {
   flex: 0 1 auto;
   min-width: 140px;
-  margin: 1em 0;
-  padding: 0 2em 0 1em;
+  margin: 1rem 0;
+  padding: 0 2rem 0 1rem;
 }
 
 .gho-bottom-figure-row .field__items > .field__item {
@@ -35,7 +35,7 @@
 }
 
 .gho-bottom-figure-row .dataset {
-  margin-top: 1rem;
   padding-top: 1rem;
+  padding-left: 1rem;
   border-top: 1px solid #ddd;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
@@ -12,14 +12,15 @@
   flex: 0 1 auto;
   min-width: 140px;
   margin: 1rem 0;
-  padding: 0 2rem 0 1rem;
 }
 
 [dir='ltr'] .gho-bottom-figure-row .field__items > .field__item {
   border-left: 1px solid #ddd;
+  padding: 0 2rem 0 1rem;
 }
 [dir='rtl'] .gho-bottom-figure-row .field__items > .field__item {
   border-right: 1px solid #ddd;
+  padding: 0 1rem 0 2rem;
 }
 
 @media screen and (min-width: 768px) {
@@ -46,3 +47,7 @@
   border-top: 1px solid #ddd;
 }
 
+[dir='rtl'] .gho-bottom-figure-row .dataset {
+  padding-left: 0;
+  padding-right: 1rem;
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
@@ -33,3 +33,9 @@
 .gho-bottom-figure-row .double-field-first {
   font-weight: 700;
 }
+
+.gho-bottom-figure-row .dataset {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #ddd;
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
@@ -15,13 +15,19 @@
   padding: 0 2rem 0 1rem;
 }
 
-.gho-bottom-figure-row .field__items > .field__item {
+[dir='ltr'] .gho-bottom-figure-row .field__items > .field__item {
   border-left: 1px solid #ddd;
+}
+[dir='rtl'] .gho-bottom-figure-row .field__items > .field__item {
+  border-right: 1px solid #ddd;
 }
 
 @media screen and (min-width: 768px) {
-  .gho-bottom-figure-row .field__items > .field__item:first-child {
+  [dir='ltr'] .gho-bottom-figure-row .field__items > .field__item:first-child {
     border-left: 0;
+  }
+  [dir='rtl'] .gho-bottom-figure-row .field__items > .field__item:first-child {
+    border-right: 0;
   }
 }
 
@@ -39,3 +45,4 @@
   padding-left: 1rem;
   border-top: 1px solid #ddd;
 }
+

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-dataset--bottom-figure-row.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-dataset--bottom-figure-row.html.twig
@@ -51,7 +51,7 @@
 <div{{ attributes.addClass(classes) }}>
   {% for item in items %}
     <div{{ item.attributes.addClass('field__item') }}>
-      Source: {{ item.content }}
+      {{ 'Source'|t }}: {{ item.content }}
     </div>
   {% endfor %}
 </div>

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-dataset--bottom-figure-row.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-dataset--bottom-figure-row.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * @file
+ * Theme override for a Bottom figure Dataset field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+    'dataset',
+    label_display == 'inline' ? 'clearfix',
+  ]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  {% for item in items %}
+    <div{{ item.attributes.addClass('field__item') }}>
+      Source: {{ item.content }}
+    </div>
+  {% endfor %}
+</div>


### PR DESCRIPTION
# GHO-11

I spent an ungodly amount of time trying to format the link but I failed so here's a PR with the text hyperlinked.

RTL layout also included in the PR now. You have to create an Arabic translation of the page to see the effect, because otherwise the `<article>` for the Article content type will itself have `dir="ltr"` as an attribute, which applies both sets in a rather strange way. I'm not sure if we can/should safeguard against that situation. It seems they'll have translations for everything.