### PR TITLE
GHO-13: Further reading

### DIFF
--- a/config/core.base_field_override.node.further_reading.promote.yml
+++ b/config/core.base_field_override.node.further_reading.promote.yml
@@ -1,0 +1,22 @@
+uuid: ec3a030b-6da7-4e59-92db-beae2f571a51
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.further_reading
+id: node.further_reading.promote
+field_name: promote
+entity_type: node
+bundle: further_reading
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.further_reading.status.yml
+++ b/config/core.base_field_override.node.further_reading.status.yml
@@ -1,0 +1,22 @@
+uuid: c944e6fc-c22e-49a8-a936-1d035050aee5
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.further_reading
+id: node.further_reading.status
+field_name: status
+entity_type: node
+bundle: further_reading
+label: Published
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.further_reading.title.yml
+++ b/config/core.base_field_override.node.further_reading.title.yml
@@ -1,0 +1,18 @@
+uuid: 66ce4012-5321-4e37-8c90-ea609a414d10
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.further_reading
+id: node.further_reading.title
+field_name: title
+entity_type: node
+bundle: further_reading
+label: 'Author / Organization'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.entity_form_display.node.further_reading.default.yml
+++ b/config/core.entity_form_display.node.further_reading.default.yml
@@ -1,0 +1,52 @@
+uuid: ec2f6771-af5a-4619-8b79-760f303ffa96
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.further_reading.field_further_source
+    - field.field.node.further_reading.field_further_url
+    - node.type.further_reading
+  module:
+    - link
+id: node.further_reading.default
+targetEntityType: node
+bundle: further_reading
+mode: default
+content:
+  field_further_url:
+    weight: 1
+    settings:
+      placeholder_url: 'https://example.com'
+      placeholder_title: 'Enter the title here'
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: 'Mark Lowcock / OCHA'
+    third_party_settings: {  }
+  translation:
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_further_source: true
+  path: true
+  promote: true
+  status: true
+  sticky: true
+  uid: true
+  url_redirects: true

--- a/config/core.entity_form_display.paragraph.further_reading.default.yml
+++ b/config/core.entity_form_display.paragraph.further_reading.default.yml
@@ -1,0 +1,34 @@
+uuid: 38f6de7d-7c4d-4b8e-953d-bbbdefaddbd3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.further_reading.field_further_reading
+    - paragraphs.paragraphs_type.further_reading
+  module:
+    - inline_entity_form
+id: paragraph.further_reading.default
+targetEntityType: paragraph
+bundle: further_reading
+mode: default
+content:
+  field_further_reading:
+    weight: 2
+    settings:
+      form_mode: default
+      label_singular: ''
+      label_plural: ''
+      allow_new: true
+      allow_existing: true
+      match_operator: CONTAINS
+      revision: false
+      override_labels: false
+      collapsible: false
+      collapsed: false
+      allow_duplicate: false
+    third_party_settings: {  }
+    type: inline_entity_form_complex
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.node.further_reading.default.yml
+++ b/config/core.entity_view_display.node.further_reading.default.yml
@@ -1,0 +1,39 @@
+uuid: 283ce13d-f00c-43fd-b3d4-abf71265035c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.further_reading.field_further_source
+    - field.field.node.further_reading.field_further_url
+    - node.type.further_reading
+  module:
+    - link
+    - user
+id: node.further_reading.default
+targetEntityType: node
+bundle: further_reading
+mode: default
+content:
+  field_further_source:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_further_url:
+    weight: 0
+    label: hidden
+    settings:
+      trim_length: null
+      rel: nofollow
+      url_only: false
+      url_plain: false
+      target: '0'
+    third_party_settings: {  }
+    type: link
+    region: content
+hidden:
+  langcode: true
+  links: true

--- a/config/core.entity_view_display.node.further_reading.teaser.yml
+++ b/config/core.entity_view_display.node.further_reading.teaser.yml
@@ -1,0 +1,25 @@
+uuid: 247bde36-5310-43d5-a658-f1e6edd425b5
+langcode: en
+status: false
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.further_reading.field_further_source
+    - field.field.node.further_reading.field_further_url
+    - node.type.further_reading
+  module:
+    - user
+id: node.further_reading.teaser
+targetEntityType: node
+bundle: further_reading
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_further_source: true
+  field_further_url: true
+  langcode: true

--- a/config/core.entity_view_display.paragraph.further_reading.default.yml
+++ b/config/core.entity_view_display.paragraph.further_reading.default.yml
@@ -1,0 +1,22 @@
+uuid: 1d3a9e87-8f99-4755-9bd3-5980b8e4a0f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.further_reading.field_further_reading
+    - paragraphs.paragraphs_type.further_reading
+id: paragraph.further_reading.default
+targetEntityType: paragraph
+bundle: further_reading
+mode: default
+content:
+  field_further_reading:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden: {  }

--- a/config/field.field.node.article.field_paragraphs.yml
+++ b/config/field.field.node.article.field_paragraphs.yml
@@ -8,6 +8,7 @@ dependencies:
     - paragraphs.paragraphs_type.bottom_figure_row
     - paragraphs.paragraphs_type.facts_and_figures
     - paragraphs.paragraphs_type.field_story
+    - paragraphs.paragraphs_type.further_reading
     - paragraphs.paragraphs_type.layout
     - paragraphs.paragraphs_type.photo_gallery
     - paragraphs.paragraphs_type.separator
@@ -29,36 +30,40 @@ settings:
   handler_settings:
     negate: 0
     target_bundles:
-      bottom_figure_row: bottom_figure_row
       layout: layout
+      text: text
       facts_and_figures: facts_and_figures
       field_story: field_story
-      text: text
       photo_gallery: photo_gallery
+      bottom_figure_row: bottom_figure_row
+      further_reading: further_reading
       separator: separator
     target_bundles_drag_drop:
       bottom_figure_row:
         enabled: true
-        weight: 8
+        weight: -14
       facts_and_figures:
         enabled: true
-        weight: 9
+        weight: -17
       field_story:
         enabled: true
-        weight: 10
+        weight: -16
+      further_reading:
+        enabled: true
+        weight: -13
       image_with_text:
-        weight: 12
+        weight: -11
         enabled: false
       layout:
         enabled: true
-        weight: 8
+        weight: -19
       photo_gallery:
         enabled: true
-        weight: 11
+        weight: -15
       separator:
         enabled: true
-        weight: 15
+        weight: -12
       text:
         enabled: true
-        weight: 10
+        weight: -18
 field_type: entity_reference_revisions

--- a/config/field.field.node.further_reading.field_further_source.yml
+++ b/config/field.field.node.further_reading.field_further_source.yml
@@ -1,0 +1,19 @@
+uuid: a2091b25-e7bc-4aac-9d84-c0fb05dccf42
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_further_source
+    - node.type.further_reading
+id: node.further_reading.field_further_source
+field_name: field_further_source
+entity_type: node
+bundle: further_reading
+label: 'Author / Organization'
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.node.further_reading.field_further_url.yml
+++ b/config/field.field.node.further_reading.field_further_url.yml
@@ -1,0 +1,23 @@
+uuid: b0af2228-792f-40d4-812a-b3e3b812bd63
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_further_url
+    - node.type.further_reading
+  module:
+    - link
+id: node.further_reading.field_further_url
+field_name: field_further_url
+entity_type: node
+bundle: further_reading
+label: URL
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 2
+field_type: link

--- a/config/field.field.paragraph.further_reading.field_further_reading.yml
+++ b/config/field.field.paragraph.further_reading.field_further_reading.yml
@@ -1,0 +1,28 @@
+uuid: e1739a50-a318-4517-b84d-594f342ef29d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_further_reading
+    - node.type.further_reading
+    - paragraphs.paragraphs_type.further_reading
+id: paragraph.further_reading.field_further_reading
+field_name: field_further_reading
+entity_type: paragraph
+bundle: further_reading
+label: 'List of links for Further Reading'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      further_reading: further_reading
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.storage.node.field_further_source.yml
+++ b/config/field.storage.node.field_further_source.yml
@@ -1,0 +1,21 @@
+uuid: a1d29452-00f1-4fd8-8e8a-8412c7b02d0b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_further_source
+field_name: field_further_source
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_further_url.yml
+++ b/config/field.storage.node.field_further_url.yml
@@ -1,0 +1,19 @@
+uuid: c43d70c0-c57a-46e1-a299-054b49429392
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_further_url
+field_name: field_further_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_further_reading.yml
+++ b/config/field.storage.paragraph.field_further_reading.yml
@@ -1,0 +1,20 @@
+uuid: c3ff1137-db93-4405-8d32-b6d231873ca8
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_further_reading
+field_name: field_further_reading
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/language.content_settings.node.further_reading.yml
+++ b/config/language.content_settings.node.further_reading.yml
@@ -1,0 +1,16 @@
+uuid: f4c7cfd5-e336-4fa3-8408-cfdddd7b3283
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.further_reading
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.further_reading
+target_entity_type_id: node
+target_bundle: further_reading
+default_langcode: site_default
+language_alterable: true

--- a/config/language.negotiation.yml
+++ b/config/language.negotiation.yml
@@ -7,6 +7,7 @@ url:
     fr: fr
     ar: ar
     es: es
+    '': null
   domains:
     en: ''
     fr: ''

--- a/config/node.type.further_reading.yml
+++ b/config/node.type.further_reading.yml
@@ -1,0 +1,17 @@
+uuid: 92d1ceca-8555-4a99-b99b-cacd3801ccfa
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: 'Further reading'
+type: further_reading
+description: 'A list of external links for more info relating to a given Article.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/config/paragraphs.paragraphs_type.further_reading.yml
+++ b/config/paragraphs.paragraphs_type.further_reading.yml
@@ -1,0 +1,10 @@
+uuid: b54d2bee-bccc-4645-a8eb-7326c4476d14
+langcode: en
+status: true
+dependencies: {  }
+id: further_reading
+label: 'Further reading'
+icon_uuid: null
+icon_default: null
+description: 'External links related to an article.'
+behavior_plugins: {  }

--- a/config/user.role.anonymous.yml
+++ b/config/user.role.anonymous.yml
@@ -16,4 +16,5 @@ permissions:
   - 'view published author media'
   - 'view published document media'
   - 'view published field_story content'
+  - 'view published further_reading content'
   - 'view published image media'

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -19,4 +19,5 @@ permissions:
   - 'view published author media'
   - 'view published document media'
   - 'view published field_story content'
+  - 'view published further_reading content'
   - 'view published image media'

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -29,6 +29,11 @@ gho-facts-and-figures:
     theme:
       components/gho-facts-and-figures/gho-facts-and-figures.css: {}
 
+gho-further-reading:
+  css:
+    theme:
+      components/gho-further-reading/gho-further-reading.css: {}
+
 gho-separator:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/components/gho-further-reading/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-further-reading/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Furhter reading list
+===================================================
+
+List of external links for further reading.

--- a/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
@@ -1,0 +1,50 @@
+/**
+ * Base styles
+ */
+.gho-further-reading {
+  max-width: 768px;
+  border-top: 1px solid #ccc;
+  position: relative; /* for pseudo positioning */
+}
+
+/**
+ * Style last link in list
+ */
+.gho-further-reading:last-child {
+  border-bottom: 1px solid #ccc;
+}
+
+/**
+ * Actual hyperlink
+ *
+ * It's styled as a block element to allow all aspects of the component to be
+ * clickable: the chevron and authorship line.
+ */
+.gho-further-reading__link a {
+  display: block;
+  font-weight: 700;
+  padding: 1rem 0 3rem;
+}
+.gho-further-reading__link a::after {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.5em;
+  font-weight: 400;
+}
+@media screen and (min-width: 576px) {
+  .gho-further-reading__link a::after {
+    content: '›';
+  }
+  [dir='ltr'] .gho-further-reading__link a::after {
+    right: 1rem;
+  }
+  [dir='rtl'] .gho-further-reading__link a::after {
+    left: 1rem;
+  }
+}
+
+.gho-further-reading__source {
+  margin-top: -3rem;
+  margin-bottom: 1rem;
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
@@ -3,6 +3,22 @@
  */
 .gho-further-reading {
   max-width: 768px;
+  margin-bottom: 1rem;
+}
+
+/**
+ * Title
+ */
+.gho-further-reading__title {
+  color: #000;
+  font-size: 1.25em;
+  font-weight: 700;
+}
+
+/**
+ * List item
+ */
+.gho-further-reading__item {
   border-top: 1px solid #ccc;
   position: relative; /* for pseudo positioning */
 }
@@ -10,7 +26,7 @@
 /**
  * Style last link in list
  */
-.gho-further-reading:last-child {
+.gho-further-reading__item:last-child {
   border-bottom: 1px solid #ccc;
 }
 
@@ -44,6 +60,9 @@
   }
 }
 
+/**
+ * Author / Organization
+ */
 .gho-further-reading__source {
   margin-top: -3rem;
   margin-bottom: 1rem;

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--field-further-reading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--field-further-reading.html.twig
@@ -1,0 +1,54 @@
+{#
+/**
+ * @file
+ * Theme override for a Further Reading field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+    label_display == 'inline' ? 'clearfix',
+  ]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--field-further-reading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--field-further-reading.html.twig
@@ -44,11 +44,15 @@
     'field--type-' ~ field_type|clean_class,
     'field--label-' ~ label_display,
     label_display == 'inline' ? 'clearfix',
+    'gho-further-reading',
   ]
 %}
 
 <div{{ attributes.addClass(classes) }}>
-  {% for item in items %}
-    {{ item.content }}
-  {% endfor %}
+  <p class="gho-further-reading__title">{{ 'Further reading'|t }}</p>
+  <div class="gho-further-reading__items">
+    {% for item in items %}
+      {{ item.content }}
+    {% endfor %}
+  </div>
 </div>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--further-reading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--further-reading.html.twig
@@ -79,7 +79,7 @@
     node.isSticky() ? 'node--sticky',
     not node.isPublished() ? 'node--unpublished',
     view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
-    'gho-further-reading',
+    'gho-further-reading__item',
   ]
 %}
 <article{{ attributes.addClass(classes) }}>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--further-reading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--further-reading.html.twig
@@ -1,0 +1,88 @@
+{#
+/**
+ * @file
+ * Theme override to display a list of Further reading links.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-further-reading') }}
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+    'gho-further-reading',
+  ]
+%}
+<article{{ attributes.addClass(classes) }}>
+  <div class="gho-further-reading__link">{{ content }}</div>
+  <div class="gho-further-reading__source">{{ label }}</div>
+</article>


### PR DESCRIPTION
# GHO-13

New content type, paragraph type, and theming for Further reading list.

I have to say upfront: I am not _in love_ with the solution here, but I wanted to create a list of links which could be moved around as one unit, while also allowing the list to be reordered within the larger component. Ensuring a simple-ish form while satisfying those two UX issues is what motivated me to use the following solution.

I tried a couple methods:

- Initially I made a very basic Paragraph type containing a Link and a Label. Without removing the `.field__item` wrapper on all Paragraphs within Article, I couldn't easily style the successive links. Plus, it was possible to move one link without the others being taken for the ride.
- I tried using the `double_field` plus the formatter that we went with on Bottom figures.. the UX was so ugly when entering content, very unclear to me even as the creator of the widget
- **Solution in PR:** I settled for a list of entity references, using the mandatory Title field as the "Author / Org" credit line. This lets them be created on the fly, translated easily, and be re-used as an existing entity on multiple pages.

![image](https://user-images.githubusercontent.com/254753/96423776-195db580-11fa-11eb-900b-2d3fce4df8a5.png)

## Testing

```sh
$ drush cim
$ drush cr # for theme library
```

Tested LTR/RTL on macOS Chome/FF, Win7 IE11.