### PR TITLE
GHO-12: Appeals tags

### DIFF
--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
@@ -20,9 +21,15 @@ targetEntityType: node
 bundle: article
 mode: default
 content:
+  field_appeals:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
   field_author:
     type: inline_entity_form_complex
-    weight: 3
+    weight: 4
     settings:
       form_mode: default
       override_labels: true
@@ -39,22 +46,22 @@ content:
     region: content
   field_hero_image:
     type: media_library_widget
-    weight: 4
+    weight: 5
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    weight: 7
+    weight: 8
     settings:
       preview_view_mode: default
-      nesting_depth: '4'
+      nesting_depth: 4
       require_layouts: 0
     third_party_settings: {  }
     type: layout_paragraphs
     region: content
   field_summary:
-    weight: 6
+    weight: 7
     settings:
       rows: 5
       placeholder: ''
@@ -63,7 +70,7 @@ content:
     region: content
   field_thumbnail_image:
     type: media_library_widget
-    weight: 5
+    weight: 6
     settings:
       media_types: {  }
     third_party_settings: {  }
@@ -77,7 +84,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -85,7 +92,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   title:

--- a/config/core.entity_form_display.taxonomy_term.appeals.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.appeals.default.yml
@@ -1,0 +1,33 @@
+uuid: f207c82f-9109-423c-9a66-ed55c7c1d633
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.appeals.field_appeal_extended
+    - taxonomy.vocabulary.appeals
+id: taxonomy_term.appeals.default
+targetEntityType: taxonomy_term
+bundle: appeals
+mode: default
+content:
+  field_appeal_extended:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  description: true
+  langcode: true
+  path: true
+  status: true

--- a/config/core.entity_view_display.node.article.default.yml
+++ b/config/core.entity_view_display.node.article.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
@@ -17,9 +18,18 @@ targetEntityType: node
 bundle: article
 mode: default
 content:
+  field_appeals:
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
   field_author:
     type: entity_reference_entity_view
-    weight: 2
+    weight: 3
     label: hidden
     settings:
       view_mode: default
@@ -28,7 +38,7 @@ content:
     region: content
   field_hero_image:
     type: entity_reference_entity_view
-    weight: 1
+    weight: 2
     label: hidden
     settings:
       view_mode: hero_image
@@ -36,7 +46,7 @@ content:
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       view_mode: default

--- a/config/core.entity_view_display.node.article.teaser.yml
+++ b/config/core.entity_view_display.node.article.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
@@ -35,6 +36,7 @@ content:
       link: false
     third_party_settings: {  }
 hidden:
+  field_appeals: true
   field_author: true
   field_hero_image: true
   field_paragraphs: true

--- a/config/core.entity_view_display.taxonomy_term.appeals.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.appeals.default.yml
@@ -1,0 +1,23 @@
+uuid: bb4a1997-2d6d-4a9c-931b-a32f947074a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.appeals.field_appeal_extended
+    - taxonomy.vocabulary.appeals
+id: taxonomy_term.appeals.default
+targetEntityType: taxonomy_term
+bundle: appeals
+mode: default
+content:
+  field_appeal_extended:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden:
+  description: true
+  langcode: true

--- a/config/field.field.node.article.field_appeals.yml
+++ b/config/field.field.node.article.field_appeals.yml
@@ -1,0 +1,29 @@
+uuid: d9806ad0-c77b-457f-a248-25e6700050b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_appeals
+    - node.type.article
+    - taxonomy.vocabulary.appeals
+id: node.article.field_appeals
+field_name: field_appeals
+entity_type: node
+bundle: article
+label: Appeals
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      appeals: appeals
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.appeals.field_appeal_extended.yml
+++ b/config/field.field.taxonomy_term.appeals.field_appeal_extended.yml
@@ -1,0 +1,19 @@
+uuid: 39364d11-c621-4b3e-ab9f-768050d11a43
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_appeal_extended
+    - taxonomy.vocabulary.appeals
+id: taxonomy_term.appeals.field_appeal_extended
+field_name: field_appeal_extended
+entity_type: taxonomy_term
+bundle: appeals
+label: 'Extended name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.taxonomy_term.appeals.field_appeal_extended.yml
+++ b/config/field.field.taxonomy_term.appeals.field_appeal_extended.yml
@@ -12,7 +12,7 @@ bundle: appeals
 label: 'Extended name'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/field.storage.node.field_appeals.yml
+++ b/config/field.storage.node.field_appeals.yml
@@ -1,0 +1,20 @@
+uuid: a082ece1-266f-4c02-837c-231369d6f92e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_appeals
+field_name: field_appeals
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_appeal_extended.yml
+++ b/config/field.storage.taxonomy_term.field_appeal_extended.yml
@@ -1,0 +1,21 @@
+uuid: b3e22064-664f-44de-9d50-cc05ddb71699
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_appeal_extended
+field_name: field_appeal_extended
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/language.content_settings.taxonomy_term.appeals.yml
+++ b/config/language.content_settings.taxonomy_term.appeals.yml
@@ -1,0 +1,11 @@
+uuid: f292e02e-093b-4b01-8267-4ec3dc9fff26
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.appeals
+id: taxonomy_term.appeals
+target_entity_type_id: taxonomy_term
+target_bundle: appeals
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.taxonomy_term.appeals.yml
+++ b/config/language.content_settings.taxonomy_term.appeals.yml
@@ -4,6 +4,11 @@ status: true
 dependencies:
   config:
     - taxonomy.vocabulary.appeals
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
 id: taxonomy_term.appeals
 target_entity_type_id: taxonomy_term
 target_bundle: appeals

--- a/config/taxonomy.vocabulary.appeals.yml
+++ b/config/taxonomy.vocabulary.appeals.yml
@@ -1,0 +1,8 @@
+uuid: fdcc56d4-e3ca-4664-af4c-f6cdecbe39cf
+langcode: en
+status: true
+dependencies: {  }
+name: Appeals
+vid: appeals
+description: ''
+weight: 0

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -4,6 +4,11 @@ global-styling:
       css/styles.css: {}
 
 # Custom components
+gho-appeals-tags:
+  css:
+    theme:
+      components/gho-appeals-tags/gho-appeals-tags.css: {}
+
 gho-author:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Appeals Tag Component
+====================================================
+
+Color-coded Appeals tags match the existing conventions on Hum-Insight and FTS.

--- a/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/gho-appeals-tags.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/gho-appeals-tags.css
@@ -31,6 +31,9 @@
 .gho-appeals-tag--rrp {
   background-color: #e66751;
 }
+.gho-appeals-tag--rmrp {
+  background-color: #f9a356;
+}
 .gho-appeals-tag--other {
   background-color: #87cfad;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/gho-appeals-tags.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/gho-appeals-tags.css
@@ -1,0 +1,36 @@
+/**
+ * Base component styles for the collection of tags
+ */
+.gho-appeals-tags {
+  display: flex;
+  flex-flow: row nowrap;
+  margin: 1rem -0.25rem;
+}
+
+/**
+ * Individual tag
+ */
+.gho-appeals-tag {
+  flex: 0 0 auto;
+  margin: 0 .25rem;
+  min-width: 4em;
+  display: inline-block;
+  text-align: center;
+  background: #555;
+  color: #fff;
+  font-size: .75em;
+  font-weight: 700;
+}
+
+.gho-appeals-tag--hrp {
+  background-color: #5090cd;
+}
+.gho-appeals-tag--fa {
+  background-color: #8869ae;
+}
+.gho-appeals-tag--rrp {
+  background-color: #e66751;
+}
+.gho-appeals-tag--other {
+  background-color: #87cfad;
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/gho-appeals-tags.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/gho-appeals-tags.css
@@ -16,14 +16,14 @@
   min-width: 4em;
   display: inline-block;
   text-align: center;
-  background: #555;
+  background: #5090cd;
   color: #fff;
   font-size: .75em;
   font-weight: 700;
 }
 
 .gho-appeals-tag--hrp {
-  background-color: #5090cd;
+  background-color: #5090cd; /* default */
 }
 .gho-appeals-tag--fa {
   background-color: #8869ae;

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--field-appeals.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--field-appeals.html.twig
@@ -1,0 +1,50 @@
+{#
+/**
+ * @file
+ * Theme override for an Appeals tag field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-appeals-tags') }}
+{%
+  set classes = [
+    'gho-appeals-tags',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--appeals.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--appeals.html.twig
@@ -31,6 +31,6 @@
   ]
 %}
 {% set tagname = name|render|striptags|trim %}
-<div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes, 'gho-appeals-tag--' ~ tagname|lower) }} title="{{ content.field_appeal_extended|render|striptags|trim }}">
+<div{{ attributes.addClass(classes, 'gho-appeals-tag--' ~ tagname|lower) }} title="{{ content.field_appeal_extended|render|striptags|trim }}">
   {{- tagname -}}
 </div>

--- a/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--appeals.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--appeals.html.twig
@@ -31,6 +31,6 @@
   ]
 %}
 {% set tagname = name|render|striptags|trim %}
-<div{{ attributes.addClass(classes, 'gho-appeals-tag--' ~ tagname|lower) }} title="{{ content.field_appeal_extended|render|striptags|trim }}">
+<div{{ attributes.addClass(classes, 'gho-appeals-tag--' ~ tagname|clean_class) }} title="{{ content.field_appeal_extended|render|striptags|trim }}">
   {{- tagname -}}
 </div>

--- a/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--appeals.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--appeals.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override to display an Appeals taxonomy term.
+ *
+ * Available variables:
+ * - url: URL of the current term.
+ * - name: (optional) Name of the current term.
+ * - content: Items for the content of the term (fields and description).
+ *   Use 'content' to print them all, or print a subset such as
+ *   'content.description'. Use the following code to exclude the
+ *   printing of a given child element:
+ *   @code
+ *   {{ content|without('description') }}
+ *   @endcode
+ * - attributes: HTML attributes for the wrapper.
+ * - page: Flag for the full page state.
+ * - term: The taxonomy term entity, including:
+ *   - id: The ID of the taxonomy term.
+ *   - bundle: Machine name of the current vocabulary.
+ * - view_mode: View mode, e.g. 'full', 'teaser', etc.
+ *
+ * @see template_preprocess_taxonomy_term()
+ */
+#}
+{%
+  set classes = [
+    'taxonomy-term',
+    'vocabulary-' ~ term.bundle|clean_class,
+    'gho-appeals-tag',
+  ]
+%}
+{% set tagname = name|render|striptags|trim %}
+<div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes, 'gho-appeals-tag--' ~ tagname|lower) }} title="{{ content.field_appeal_extended|render|striptags|trim }}">
+  {{- tagname -}}
+</div>


### PR DESCRIPTION
# GHO-12

PR contains config/theming for Appeals tags. They're attached to Article nodes but I think the template names I chose to overrode mean it will work anywhere (as paragraph, on different content types, etc)

The colors are stored in the component-specific CSS and they came straight off of hum-insight.info production. 

## Testing

```sh
$ drush cim
$ drush cr
```

After importing config, create taxonomy terms with the following titles: HRP, FA, RRP, Other — they should automatically pick up the appropriate colors and appear like so:

![image](https://user-images.githubusercontent.com/254753/96442931-2be0ea80-120c-11eb-8793-da22fae15ffe.png)

I used similar styles to some of the other flex components (negative margin on container) to ensure that RTL works out of the box. The tags themselves are English only and not translatable. I used the [Arabic-language 2020 GHO PDF](https://www.humanitarianresponse.info/sites/www.humanitarianresponse.info/files/documents/files/gho-2020_ar_web.pdf) (see page 28) as the basis for my decision, which uses latin-character tags amongst the otherwise arabic content.