### PR TITLE
[GHO-13] Further reading part 2 - custom widget/formatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
         "drupal/imageapi_optimize_binaries": "^1.0-alpha2",
         "drupal/inline_entity_form": "^1.0-rc8",
         "drupal/layout_paragraphs": "1.0.x-dev",
-        "drupal/link_attributes": "^1.11",
         "drupal/maintenance200": "^1.0",
         "drupal/paragraphs": "^1.12",
         "drupal/paragraphs_viewmode": "^1.0-alpha2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91ed50535de604422cd91ffa451543b1",
+    "content-hash": "7dabd560044be43a00e42476d5141ce4",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3168,7 +3168,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_paragraphs.git",
-                "reference": "9400ea67f6666c1f08900a527989ee613608d051"
+                "reference": "04a9ac9ec0ca0d4dac4de99a4e44c10a0a954fbc"
             },
             "require": {
                 "drupal/core": "^8 || ^9",
@@ -3180,8 +3180,8 @@
                     "dev-1.0.x": "1.0.x-dev"
                 },
                 "drupal": {
-                    "version": "1.0.0-beta3+14-dev",
-                    "datestamp": "1602167149",
+                    "version": "1.0.0-beta3+16-dev",
+                    "datestamp": "1602864912",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -3211,51 +3211,7 @@
                 "source": "http://cgit.drupalcode.org/layout_paragraphs",
                 "issues": "https://www.drupal.org/project/issues/layout_paragraphs"
             },
-            "time": "2020-10-09T13:13:02+00:00"
-        },
-        {
-            "name": "drupal/link_attributes",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/link_attributes.git",
-                "reference": "8.x-1.11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/link_attributes-8.x-1.11.zip",
-                "reference": "8.x-1.11",
-                "shasum": "ca8c7e71c38350e3784dc3d1f779d700f55df818"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.11",
-                    "datestamp": "1598323550",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "larowlan",
-                    "homepage": "https://www.drupal.org/user/395439"
-                }
-            ],
-            "description": "Provides a widget to allow settings of link attributes for menu links.",
-            "homepage": "https://www.drupal.org/project/link_attributes",
-            "support": {
-                "source": "https://git.drupalcode.org/project/link_attributes"
-            }
+            "time": "2020-10-20T18:21:51+00:00"
         },
         {
             "name": "drupal/maintenance200",
@@ -4948,20 +4904,20 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v9.99.99",
+            "version": "v9.99.100",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7"
+                "php": ">= 7"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.*|5.*",
@@ -4989,7 +4945,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2018-07-02T15:55:56+00:00"
+            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "pear/archive_tar",
@@ -7690,20 +7646,20 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.43.1",
+            "version": "v1.44.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "2311602f6a208715252febe682fa7c38e56a3373"
+                "reference": "e7c93a4af5eba2b0b3cf51d540e0a131187d7410"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/2311602f6a208715252febe682fa7c38e56a3373",
-                "reference": "2311602f6a208715252febe682fa7c38e56a3373",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/e7c93a4af5eba2b0b3cf51d540e0a131187d7410",
+                "reference": "e7c93a4af5eba2b0b3cf51d540e0a131187d7410",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
+                "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
@@ -7713,7 +7669,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.43-dev"
+                    "dev-master": "1.44-dev"
                 }
             },
             "autoload": {
@@ -7760,7 +7716,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-05T15:05:05+00:00"
+            "time": "2020-10-21T12:32:35+00:00"
         },
         {
             "name": "typo3/phar-stream-wrapper",

--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -13,9 +13,9 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
+    - gho_fields
     - inline_entity_form
     - layout_paragraphs
-    - link_attributes
     - media_library
     - path
     - text
@@ -52,18 +52,8 @@ content:
     settings:
       placeholder_url: 'https://example.com'
       placeholder_title: 'Example URL Title'
-      enabled_attributes:
-        source: true
-        id: false
-        name: false
-        target: false
-        rel: false
-        class: false
-        accesskey: false
-        aria-label: false
-        title: false
     third_party_settings: {  }
-    type: link_attributes
+    type: gho_further_reading_link
     region: content
   field_hero_image:
     type: media_library_widget

--- a/config/core.entity_form_display.taxonomy_term.appeals.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.appeals.default.yml
@@ -26,6 +26,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+    region: content
 hidden:
   description: true
   langcode: true

--- a/config/core.entity_view_display.node.article.default.yml
+++ b/config/core.entity_view_display.node.article.default.yml
@@ -13,8 +13,8 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
+    - gho_fields
     - layout_paragraphs
-    - link
     - user
 id: node.article.default
 targetEntityType: node
@@ -42,14 +42,9 @@ content:
   field_further_reading:
     weight: 5
     label: hidden
-    settings:
-      trim_length: null
-      rel: nofollow
-      url_only: false
-      url_plain: false
-      target: '0'
+    settings: {  }
     third_party_settings: {  }
-    type: link
+    type: gho_further_reading_link
     region: content
   field_hero_image:
     type: entity_reference_entity_view

--- a/config/core.entity_view_display.node.article.related_article.yml
+++ b/config/core.entity_view_display.node.article.related_article.yml
@@ -42,6 +42,7 @@ content:
       link: false
     third_party_settings: {  }
 hidden:
+  field_appeals: true
   field_author: true
   field_further_reading: true
   field_hero_image: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -34,7 +34,6 @@ module:
   layout_discovery: 0
   layout_paragraphs: 0
   link: 0
-  link_attributes: 0
   locale: 0
   maintenance200: 0
   media: 0

--- a/html/modules/custom/gho_fields/README.md
+++ b/html/modules/custom/gho_fields/README.md
@@ -1,13 +1,28 @@
 Global Humanitarian Overview - Fields Module
 ============================================
 
-This module provides some field formatters and widgets:
+This module provides some field formatters, widgets and templates.
 
-- **GHO dataset link formatter**:
+Dataset links
+-------------
 
-  Link field formatter to display "download dataset" links.
+- [Formatter](src/Plugin/Field/FieldFormatter/GhoDatasetLinkFormatter.php)
 
-- **GHO dataset link widget**:
+  Uses the [gho-further-reading-link-formatter.html.twig](templates/gho-dataset-link-formatter.html.twig) template with the `url` and `source` (repurposed link title) variables.
 
-  Link field widget to display "download dataset" links.
-  This just updates the label of the title field...
+- [Widget](src/Plugin/Field/FieldWidget/GhoDatasetLinkWidget.php)
+
+  Simply renames the `title` field to "Source".
+
+
+Further reading links
+---------------------
+
+- [Formatter](src/Plugin/Field/FieldFormatter/GhoFurtherReadingLinkFormatter.php)
+
+  Uses the [gho-further-reading-link-formatter.html.twig](templates/gho-further-reading-link-formatter.html.twig) template with the `title`, `url`
+  and `source` variables.
+
+- [Widget](src/Plugin/Field/FieldWidget/GhoFurtherReadingLinkWidget.php)
+
+  Add a mandatory `source` field in addition to the `uri` and `title`.

--- a/html/modules/custom/gho_fields/config/schema/gho_fields.schema.yml
+++ b/html/modules/custom/gho_fields/config/schema/gho_fields.schema.yml
@@ -1,10 +1,21 @@
+# Formatters.
 field.formatter.settings.gho_dataset_link:
   type: mapping
-  label: 'GHO dataset link format settings'
+  label: 'GHO dataset link formatter settings'
+  mapping:
+    # No settings.
+field.formatter.settings.gho_further_reading_link:
+  type: mapping
+  label: 'GHO further reading link formatter settings'
   mapping:
     # No settings.
 
+# Widgets.
 field.widget.settings.gho_dataset_link:
   # Inherit the settings from the link widget.
   type: field.widget.settings.link_default
   label: 'GHO dataset link widget settings'
+field.widget.settings.gho_further_reading_link:
+  # Inherit the settings from the link widget.
+  type: field.widget.settings.link_default
+  label: 'GHO further reading link widget settings'

--- a/html/modules/custom/gho_fields/gho_fields.link_attributes.yml
+++ b/html/modules/custom/gho_fields/gho_fields.link_attributes.yml
@@ -1,2 +1,0 @@
-source:
-  title: Author / Source

--- a/html/modules/custom/gho_fields/gho_fields.module
+++ b/html/modules/custom/gho_fields/gho_fields.module
@@ -16,5 +16,12 @@ function gho_fields_theme() {
         'source' => NULL,
       ],
     ],
+    'gho_further_reading_link_formatter' => [
+      'variables' => [
+        'url' => NULL,
+        'title' => NULL,
+        'source' => NULL,
+      ],
+    ],
   ];
 }

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoFurtherReadingLinkFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoFurtherReadingLinkFormatter.php
@@ -28,9 +28,10 @@ class GhoFurtherReadingLinkFormatter extends FormatterBase {
 
     foreach ($items as $delta => $item) {
       // Retrieve the source information which is stored as a link attribute.
-      $options = $item->options;
-      $attributes = $options['attributes'] ?? [];
-      $source = $attributes['source'] ?? '';
+      $source = '';
+      if (isset($item->options['attributes']['source'])) {
+        $source = $item->options['attributes']['source'];
+      }
 
       $url = $this->buildUrl($item);
       $element[$delta] = [
@@ -58,6 +59,9 @@ class GhoFurtherReadingLinkFormatter extends FormatterBase {
 
     $options = $item->options;
     $options += $url->getOptions();
+
+    // No need to have the source added as attribute to the link.
+    unset($options['attributes']['source']);
 
     $url->setOptions($options);
 

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoFurtherReadingLinkFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoFurtherReadingLinkFormatter.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\gho_fields\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Url;
+use Drupal\link\LinkItemInterface;
+
+/**
+ * Plugin implementation of the 'gho_further_reading_link' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "gho_further_reading_link",
+ *   label = @Translation("GHO further reading link"),
+ *   field_types = {
+ *     "link"
+ *   }
+ * )
+ */
+class GhoFurtherReadingLinkFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+
+    foreach ($items as $delta => $item) {
+      // Retrieve the source information which is stored as a link attribute.
+      $options = $item->options;
+      $attributes = $options['attributes'] ?? [];
+      $source = $attributes['source'] ?? '';
+
+      $url = $this->buildUrl($item);
+      $element[$delta] = [
+        '#theme' => 'gho_further_reading_link_formatter',
+        '#url' => $url,
+        '#title' => $item->title ?? $url->toString(),
+        '#source' => $source,
+      ];
+    }
+
+    return $element;
+  }
+
+  /**
+   * Builds the \Drupal\Core\Url object for a link field item.
+   *
+   * @param \Drupal\link\LinkItemInterface $item
+   *   The link field item being rendered.
+   *
+   * @return \Drupal\Core\Url
+   *   A Url object.
+   */
+  protected function buildUrl(LinkItemInterface $item) {
+    $url = $item->getUrl() ?: Url::fromRoute('<none>');
+
+    $options = $item->options;
+    $options += $url->getOptions();
+
+    $url->setOptions($options);
+
+    return $url;
+  }
+
+}

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldWidget/GhoFurtherReadingLinkWidget.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldWidget/GhoFurtherReadingLinkWidget.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\gho_fields\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\link\Plugin\Field\FieldWidget\LinkWidget;
+
+/**
+ * Plugin implementation of the 'gho_further_reading_link' widget.
+ *
+ * @FieldWidget(
+ *   id = "gho_further_reading_link",
+ *   label = @Translation("GHO further reading link"),
+ *   field_types = {
+ *     "link"
+ *   }
+ * )
+ */
+class GhoFurtherReadingLinkWidget extends LinkWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+    $item = $items[$delta];
+
+    // Get the base selector for the URI field.
+    $parents = $element['#field_parents'];
+    $parents[] = $this->fieldDefinition->getName();
+    $selector = array_shift($parents);
+    if (!empty($parents)) {
+      $selector .= '[' . implode('][', $parents) . ']';
+    }
+    $selector .= '[' . $delta . '][uri]';
+
+    // Retrieve the default source value which is stored as an attribute.
+    $options = $item->get('options')->getValue();
+    $attributes = $options['attributes'] ?? [];
+    $source = $attributes['source'] ?? NULL;
+
+    $element['source'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Author / Source'),
+      '#default_value' => $source,
+      // Mark the source as required when the URI is filled.
+      '#states' => [
+        'required' => [
+          ':input[name="' . $selector . '"]' => ['filled' => TRUE],
+        ],
+      ],
+    ];
+
+    // Add a callback to validate the source field ensuring it's not empty
+    // when the URI field is filled.
+    $element['#element_validate'][] = [
+      get_called_class(),
+      'validateSourceElement',
+    ];
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    $values = parent::massageFormValues($values, $form, $form_state);
+    foreach ($values as $delta => $value) {
+      if (isset($value['source'])) {
+        $values[$delta]['options']['attributes']['source'] = $value['source'];
+        unset($values[$delta]['source']);
+      }
+    }
+    return $values;
+  }
+
+  /**
+   * Form element validation handler for the 'source' element.
+   *
+   * Display an error if the source field is empty while the URI is filled.
+   *
+   * @param array $element
+   *   Form element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   * @param array $form
+   *   Form.
+   */
+  public static function validateSourceElement(array &$element, FormStateInterface $form_state, array $form) {
+    if ($element['uri']['#value'] !== '' && $element['title']['#value'] === '') {
+      $error = t('The @source field is required if there is @uri input.', [
+        '@source' => $element['source']['#title'],
+        '@uri' => $element['uri']['#title'],
+      ]);
+      $form_state->setError($element['source'], $error);
+    }
+  }
+
+}

--- a/html/modules/custom/gho_fields/templates/gho-further-reading-link-formatter.html.twig
+++ b/html/modules/custom/gho_fields/templates/gho-further-reading-link-formatter.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a GHO further reading link formatter.
+ *
+ * Available variables:
+ * - title: Link title
+ * - url: Link url
+ * - source: Link author/source
+ *
+ * @ingroup themeable
+ */
+#}
+{% set link = link(title, url, {'rel': 'nofollow'})|render %}
+<div class="gho-further-reading-link">
+  {{ link }}
+  {% if source %}
+  <p><span class="visually-hidden">{{ 'Source: '|t}}</span>{{ source }}</p>
+  {% endif %}
+</div>

--- a/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
@@ -41,13 +41,17 @@
 }
 .gho-further-reading a::before {
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  /* This, combined with the line-height, ensures the chevron is centered
+   * vertically. */
+  top: calc(50% - 0.75em);
   font-size: 1.5em;
   font-weight: 400;
+  line-height: 1;
 }
 @media screen and (min-width: 576px) {
   .gho-further-reading a::before {
+    /* @todo this should be replaced with a SVG icon: cd-icon--arrow-right and
+     * maybe cd-icon--arrow-left for ltr?. */
     content: '›';
   }
   [dir='ltr'] .gho-further-reading a::before {
@@ -61,7 +65,13 @@
 /**
  * Author / Source
  */
-.gho-further-reading .source {
-  margin-top: -3rem;
-  margin-bottom: 1rem;
+.gho-further-reading p {
+  /* Move the source close to the link text. This puts the source in the
+   * clicking area of the link at the cost of making it non selectable.
+   * This can be "fixed" by adding `position: relative;` but then it's not
+   * "clickable" anymore.
+   *
+   * Note: if the source is long then when it wraps to multiple lines, it may
+   * not be fully included in the `3rem` space anymore. */
+  margin: -3rem 0 1rem 0;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
@@ -50,15 +50,18 @@
 }
 @media screen and (min-width: 576px) {
   .gho-further-reading a::before {
-    /* @todo this should be replaced with a SVG icon: cd-icon--arrow-right and
-     * maybe cd-icon--arrow-left for ltr?. */
+    /* @todo Maybe this should be replaced with a SVG icon in the markup:
+     * cd-icon--arrow-right for LTR and maybe cd-icon--arrow-left for RTL or
+     * a simply a CSS rotation?. */
     content: '›';
   }
   [dir='ltr'] .gho-further-reading a::before {
+    left: auto;
     right: 1rem;
   }
   [dir='rtl'] .gho-further-reading a::before {
     left: 1rem;
+    right: auto;
   }
 }
 

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--field-further-reading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--field-further-reading.html.twig
@@ -74,10 +74,7 @@
       <div class="field__items">
     {% endif %}
     {% for item in items %}
-      <div{{ item.attributes.addClass('field__item') }}>
-        {{ item.content }}
-        <p class="source"><span class="visually-hidden">{{ 'Source:'|t }}</span>{# 💰 #}</p>
-      </div>
+      <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
     {% endfor %}
     {% if multiple %}
       </div>


### PR DESCRIPTION
Ticket: GHO-13

This PR is a complement for https://github.com/UN-OCHA/gho-site/pull/37.

It adds a custom widget and formatter (and template) for the further reading links similar to what was done for the `Dataset` links.

Initially it was going to extend what `link_attributes` does but after looking at the code, it appeared we don't need the module and a simple custom widget would do the trick to add the `source` field. So this PR also removes the `link_attributes` module.

**Form widget**

<img width="983" alt="Screen Shot 2020-10-22 at 13 05 23" src="https://user-images.githubusercontent.com/696348/96823355-4ebb0b00-1467-11eb-9c8d-17d068c7ee5c.png">

Note: there is no placeholder for the source. If we think one should be added, then this can be done by adding a `#placeholder` in the `GhoFurtherReadingLinkWidget.php` file.

**Formatter**

<img width="804" alt="Screen Shot 2020-10-22 at 13 08 38" src="https://user-images.githubusercontent.com/696348/96823907-85455580-1468-11eb-85aa-616c0256cbde.png">

**Styling/template**

I think that the `›` for the chevron should be replaced by a SVG icon in the markup (`cd-icon--arrow-right`) that could be rotated via CSS on RTL.

There is a default template: `gho-further-reading-link-formatter.html.twig` in the `gho_fields` module that could be overriden in the `common_design_subtheme` for that.

I added some notes in the `components/gho-further-reading/gho-further-reading.css` file about some potential issues with the source.

## Testing

This PR removes the `link_attributes` module so to avoid some issues, I would recommend to first uninstall it before switching to the branch or switch to `develop`, run `drush cim` and then switch to this branch.

