### PR TITLE
GHO-14: Related Article followups

### DIFF
--- a/config/responsive_image.styles.related_article_thumbnail.yml
+++ b/config/responsive_image.styles.related_article_thumbnail.yml
@@ -18,7 +18,7 @@ image_style_mappings:
     multiplier: 2x
     image_mapping_type: sizes
     image_mapping:
-      sizes: 'calc(((100vw - 48px) * .4) - 1rem), (min-width: 1008px) calc(((960px) * .4) - 1rem)'
+      sizes: 'calc(((100vw - 48px) * .4) - 1rem)'
       sizes_image_styles:
         - 1104_x_678
         - 368_x_226

--- a/html/themes/custom/common_design_subtheme/components/gho-related-article/gho-related-article.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-related-article/gho-related-article.css
@@ -2,7 +2,13 @@
  * List styles
  */
 .gho-related-articles {
+}
 
+/**
+ * List title
+ */
+.gho-related-articles__title {
+  color: black;
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/gho-related-article/gho-related-article.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-related-article/gho-related-article.css
@@ -9,7 +9,6 @@
  * Individual Article
  */
 .gho-related-article {
-  max-width: 960px;
   padding: 1rem 0;
   position: relative; /* title will be positioned absolutely */
 }
@@ -51,7 +50,7 @@
 @media screen and (min-width: 768px) {
   .gho-related-article .field--name-field-thumbnail-image {
     width: calc(40% - 1rem);
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
   }
   [dir='ltr'] .gho-related-article .field--name-field-thumbnail-image {
     float: left;
@@ -62,17 +61,9 @@
     margin-left: 1rem;
   }
 }
-@media screen and (min-width: 960px) {
+@media screen and (min-width: 1024px) {
   .gho-related-article .field--name-field-thumbnail-image {
-    height: 226px;
-    width: calc(40% - 1rem);
     margin-bottom: 0;
-  }
-  [dir='ltr'] .gho-related-article .field--name-field-thumbnail-image {
-    float: left;
-  }
-  [dir='rtl'] .gho-related-article .field--name-field-thumbnail-image {
-    float: right;
   }
 }
 

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-related-articles--article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-related-articles--article.html.twig
@@ -51,6 +51,7 @@
   set title_classes = [
     'field__label',
     label_display == 'visually_hidden' ? 'visually-hidden',
+    'gho-related-articles__title',
   ]
 %}
 
@@ -68,7 +69,7 @@
   {% endif %}
 {% else %}
   <div{{ attributes.addClass(classes) }}>
-    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    <h2{{ title_attributes.addClass(title_classes) }}>{{ 'More from this section'|t }}</h2>
     {% if multiple %}
       <div class="field__items">
     {% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--related-article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--related-article.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a Related Article node.
+ * Theme override to display a Article node using Related Article view mode.
  *
  * Available variables:
  * - node: The node entity with limited access to object properties and methods.


### PR DESCRIPTION
# GHO-14

Small follow-ups from work in #33 

- the max-width has been removed from the component, which simplified some responsive image styles config.
- I restored the title which is evident in the PDF where the component is seen in context. We originally built using the screenshot very early in the PDF which had no title.