### PR TITLE
[GHO-10] Needs and requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "drupal-composer/preserve-paths": "^0.1.5",
         "drupal/admin_denied": "^1.0",
         "drupal/allowed_formats": "^1.2",
+        "drupal/bigint": "^1.1",
         "drupal/ckeditor_config": "^3.0",
         "drupal/components": "^2.0-beta3",
         "drupal/config_split": "^1.4",
@@ -46,6 +47,7 @@
         "drupal/social_auth_hid": "^2.5",
         "drush/drush": "^10.2.2",
         "oomphinc/composer-installers-extender": "^1.1.2",
+        "phpoffice/phpspreadsheet": "^1.14.1",
         "unocha/common_design": "^2.8.3",
         "webflo/drupal-finder": "^1.0.0",
         "zaporylie/composer-drupal-optimizations": "^1.1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a1a4de351f08fe991798746ce6698aa",
+    "content-hash": "3460c557bcb7e9a2c20f7727052fb1de",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1251,16 +1251,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.10.4",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f"
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bfe91e31984e2ba76df1c1339681770401ec262f",
-                "reference": "bfe91e31984e2ba76df1c1339681770401ec262f",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
+                "reference": "ce77a7ba1770462cd705a91a151b6c3746f9c6ad",
                 "shasum": ""
             },
             "require": {
@@ -1270,13 +1270,14 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
+                "doctrine/coding-standard": "^6.0 || ^8.1",
                 "phpstan/phpstan": "^0.12.20",
                 "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -1311,13 +1312,13 @@
                 }
             ],
             "description": "Docblock Annotations Parser",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
             "keywords": [
                 "annotations",
                 "docblock",
                 "parser"
             ],
-            "time": "2020-08-10T19:35:50+00:00"
+            "time": "2020-10-26T10:28:16+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -1935,32 +1936,32 @@
         },
         {
             "name": "doctrine/reflection",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/reflection.git",
-                "reference": "55e71912dfcd824b2fdd16f2d9afe15684cfce79"
+                "reference": "fa587178be682efe90d005e3a322590d6ebb59a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/reflection/zipball/55e71912dfcd824b2fdd16f2d9afe15684cfce79",
-                "reference": "55e71912dfcd824b2fdd16f2d9afe15684cfce79",
+                "url": "https://api.github.com/repos/doctrine/reflection/zipball/fa587178be682efe90d005e3a322590d6ebb59a5",
+                "reference": "fa587178be682efe90d005e3a322590d6ebb59a5",
                 "shasum": ""
             },
             "require": {
                 "doctrine/annotations": "^1.0",
                 "ext-tokenizer": "*",
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "conflict": {
                 "doctrine/common": "<2.9"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^5.0",
+                "doctrine/coding-standard": "^6.0 || ^8.2.0",
                 "doctrine/common": "^2.10",
-                "phpstan/phpstan": "^0.11.0",
-                "phpstan/phpstan-phpunit": "^0.11.0",
-                "phpunit/phpunit": "^7.0"
+                "phpstan/phpstan": "^0.11.0 || ^0.12.20",
+                "phpstan/phpstan-phpunit": "^0.11.0 || ^0.12.16",
+                "phpunit/phpunit": "^7.5 || ^9.1.5"
             },
             "type": "library",
             "extra": {
@@ -2009,7 +2010,7 @@
                 "reflection",
                 "static"
             ],
-            "time": "2020-03-27T11:06:43+00:00"
+            "time": "2020-10-27T21:46:55+00:00"
         },
         {
             "name": "drupal-composer/drupal-scaffold",
@@ -2199,6 +2200,54 @@
             }
         },
         {
+            "name": "drupal/bigint",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/bigint.git",
+                "reference": "8.x-1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/bigint-8.x-1.1.zip",
+                "reference": "8.x-1.1",
+                "shasum": "7f688cbab5ce8e3cf5270c61d762106dc584d2d6"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.1",
+                    "datestamp": "1598544615",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "alansaviolobo",
+                    "homepage": "https://www.drupal.org/user/2190830"
+                },
+                {
+                    "name": "crystaldawn",
+                    "homepage": "https://www.drupal.org/user/364638"
+                }
+            ],
+            "description": "Defines a numeric field type equivalent to a bigint db field (19) vs (10) of the default int field.",
+            "homepage": "https://www.drupal.org/project/bigint",
+            "support": {
+                "source": "https://git.drupalcode.org/project/bigint"
+            }
+        },
+        {
             "name": "drupal/ckeditor_config",
             "version": "3.0.0",
             "source": {
@@ -2366,17 +2415,17 @@
         },
         {
             "name": "drupal/config_split",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_split.git",
-                "reference": "8.x-1.6"
+                "reference": "8.x-1.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_split-8.x-1.6.zip",
-                "reference": "8.x-1.6",
-                "shasum": "e623e21c344181861e9042c19e288f721163078a"
+                "url": "https://ftp.drupal.org/files/projects/config_split-8.x-1.7.zip",
+                "reference": "8.x-1.7",
+                "shasum": "3cd524ebc0b52db31a6bef2c55693f4e62890b4f"
             },
             "require": {
                 "drupal/config_filter": "^1",
@@ -2392,8 +2441,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.6",
-                    "datestamp": "1600935570",
+                    "version": "8.x-1.7",
+                    "datestamp": "1603782947",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3219,7 +3268,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/layout_paragraphs.git",
-                "reference": "04a9ac9ec0ca0d4dac4de99a4e44c10a0a954fbc"
+                "reference": "94b90ae7af2d3143bb20471029c2e0f66799e334"
             },
             "require": {
                 "drupal/core": "^8 || ^9",
@@ -3231,8 +3280,8 @@
                     "dev-1.0.x": "1.0.x-dev"
                 },
                 "drupal": {
-                    "version": "1.0.0-beta3+16-dev",
-                    "datestamp": "1602864912",
+                    "version": "1.0.0-beta3+22-dev",
+                    "datestamp": "1603821651",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
@@ -3262,7 +3311,7 @@
                 "source": "http://cgit.drupalcode.org/layout_paragraphs",
                 "issues": "https://www.drupal.org/project/issues/layout_paragraphs"
             },
-            "time": "2020-10-20T18:21:51+00:00"
+            "time": "2020-10-27T18:27:48+00:00"
         },
         {
             "name": "drupal/maintenance200",
@@ -4729,29 +4778,28 @@
         },
         {
             "name": "league/oauth2-client",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-client.git",
-                "reference": "d9f2a1e000dc14eb3c02e15d15759385ec7ff0fb"
+                "reference": "badb01e62383430706433191b82506b6df24ad98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/d9f2a1e000dc14eb3c02e15d15759385ec7ff0fb",
-                "reference": "d9f2a1e000dc14eb3c02e15d15759385ec7ff0fb",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-client/zipball/badb01e62383430706433191b82506b6df24ad98",
+                "reference": "badb01e62383430706433191b82506b6df24ad98",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^6.0 || ^7.0",
-                "paragonie/random_compat": "^1|^2|^9.99",
-                "php": "^5.6|^7.0"
+                "paragonie/random_compat": "^1 || ^2 || ^9.99",
+                "php": "^5.6 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "eloquent/liberator": "^2.0",
-                "eloquent/phony-phpunit": "^1.0|^3.0",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "phpunit/phpunit": "^5.7|^6.0",
-                "squizlabs/php_codesniffer": "^2.3|^3.0"
+                "mockery/mockery": "^1.3",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^6.0 || ^9.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0"
             },
             "type": "library",
             "extra": {
@@ -4792,7 +4840,239 @@
                 "oauth2",
                 "single sign on"
             ],
-            "time": "2020-07-18T17:54:32+00:00"
+            "time": "2020-10-28T02:03:40+00:00"
+        },
+        {
+            "name": "maennchen/zipstream-php",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "c4c5803cc1f93df3d2448478ef79394a5981cc58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/c4c5803cc1f93df3d2448478ef79394a5981cc58",
+                "reference": "c4c5803cc1f93df3d2448478ef79394a5981cc58",
+                "shasum": ""
+            },
+            "require": {
+                "myclabs/php-enum": "^1.5",
+                "php": ">= 7.1",
+                "psr/http-message": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": ">= 6.3",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": ">= 7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "funding": [
+                {
+                    "url": "https://opencollective.com/zipstream",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2020-05-30T13:11:16+00:00"
+        },
+        {
+            "name": "markbaker/complex",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPComplex.git",
+                "reference": "9999f1432fae467bc93c53f357105b4c31bb994c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPComplex/zipball/9999f1432fae467bc93c53f357105b4c31bb994c",
+                "reference": "9999f1432fae467bc93c53f357105b4c31bb994c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "^4.0",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.3",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Complex\\": "classes/src/"
+                },
+                "files": [
+                    "classes/src/functions/abs.php",
+                    "classes/src/functions/acos.php",
+                    "classes/src/functions/acosh.php",
+                    "classes/src/functions/acot.php",
+                    "classes/src/functions/acoth.php",
+                    "classes/src/functions/acsc.php",
+                    "classes/src/functions/acsch.php",
+                    "classes/src/functions/argument.php",
+                    "classes/src/functions/asec.php",
+                    "classes/src/functions/asech.php",
+                    "classes/src/functions/asin.php",
+                    "classes/src/functions/asinh.php",
+                    "classes/src/functions/atan.php",
+                    "classes/src/functions/atanh.php",
+                    "classes/src/functions/conjugate.php",
+                    "classes/src/functions/cos.php",
+                    "classes/src/functions/cosh.php",
+                    "classes/src/functions/cot.php",
+                    "classes/src/functions/coth.php",
+                    "classes/src/functions/csc.php",
+                    "classes/src/functions/csch.php",
+                    "classes/src/functions/exp.php",
+                    "classes/src/functions/inverse.php",
+                    "classes/src/functions/ln.php",
+                    "classes/src/functions/log2.php",
+                    "classes/src/functions/log10.php",
+                    "classes/src/functions/negative.php",
+                    "classes/src/functions/pow.php",
+                    "classes/src/functions/rho.php",
+                    "classes/src/functions/sec.php",
+                    "classes/src/functions/sech.php",
+                    "classes/src/functions/sin.php",
+                    "classes/src/functions/sinh.php",
+                    "classes/src/functions/sqrt.php",
+                    "classes/src/functions/tan.php",
+                    "classes/src/functions/tanh.php",
+                    "classes/src/functions/theta.php",
+                    "classes/src/operations/add.php",
+                    "classes/src/operations/subtract.php",
+                    "classes/src/operations/multiply.php",
+                    "classes/src/operations/divideby.php",
+                    "classes/src/operations/divideinto.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@lange.demon.co.uk"
+                }
+            ],
+            "description": "PHP Class for working with complex numbers",
+            "homepage": "https://github.com/MarkBaker/PHPComplex",
+            "keywords": [
+                "complex",
+                "mathematics"
+            ],
+            "time": "2020-08-26T10:42:07+00:00"
+        },
+        {
+            "name": "markbaker/matrix",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MarkBaker/PHPMatrix.git",
+                "reference": "9567d9c4c519fbe40de01dbd1e4469dbbb66f46a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MarkBaker/PHPMatrix/zipball/9567d9c4c519fbe40de01dbd1e4469dbbb66f46a",
+                "reference": "9567d9c4c519fbe40de01dbd1e4469dbbb66f46a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpdocumentor/phpdocumentor": "2.*",
+                "phploc/phploc": "^4.0",
+                "phpmd/phpmd": "2.*",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.3",
+                "sebastian/phpcpd": "^4.0",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Matrix\\": "classes/src/"
+                },
+                "files": [
+                    "classes/src/functions/adjoint.php",
+                    "classes/src/functions/antidiagonal.php",
+                    "classes/src/functions/cofactors.php",
+                    "classes/src/functions/determinant.php",
+                    "classes/src/functions/diagonal.php",
+                    "classes/src/functions/identity.php",
+                    "classes/src/functions/inverse.php",
+                    "classes/src/functions/minors.php",
+                    "classes/src/functions/trace.php",
+                    "classes/src/functions/transpose.php",
+                    "classes/src/operations/add.php",
+                    "classes/src/operations/directsum.php",
+                    "classes/src/operations/subtract.php",
+                    "classes/src/operations/multiply.php",
+                    "classes/src/operations/divideby.php",
+                    "classes/src/operations/divideinto.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Baker",
+                    "email": "mark@demon-angel.eu"
+                }
+            ],
+            "description": "PHP Class for working with matrices",
+            "homepage": "https://github.com/MarkBaker/PHPMatrix",
+            "keywords": [
+                "mathematics",
+                "matrix",
+                "vector"
+            ],
+            "time": "2020-08-28T17:11:00+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -4858,6 +5138,52 @@
                 "xml"
             ],
             "time": "2020-10-01T13:52:52+00:00"
+        },
+        {
+            "name": "myclabs/php-enum",
+            "version": "1.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/php-enum.git",
+                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "reference": "5f36467c7a87e20fbdc51e524fd8f9d1de80187c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7",
+                "squizlabs/php_codesniffer": "1.*",
+                "vimeo/psalm": "^3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MyCLabs\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP Enum contributors",
+                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
+                }
+            ],
+            "description": "PHP Enum implementation",
+            "homepage": "http://github.com/myclabs/php-enum",
+            "keywords": [
+                "enum"
+            ],
+            "time": "2020-02-14T08:15:52+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -5211,6 +5537,102 @@
             "time": "2019-12-10T10:24:42+00:00"
         },
         {
+            "name": "phpoffice/phpspreadsheet",
+            "version": "1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
+                "reference": "a8e8068b31b8119e1daa5b1eb5715a3a8ea8305f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/a8e8068b31b8119e1daa5b1eb5715a3a8ea8305f",
+                "reference": "a8e8068b31b8119e1daa5b1eb5715a3a8ea8305f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-fileinfo": "*",
+                "ext-gd": "*",
+                "ext-iconv": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-xml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "ext-zip": "*",
+                "ext-zlib": "*",
+                "maennchen/zipstream-php": "^2.1",
+                "markbaker/complex": "^1.5|^2.0",
+                "markbaker/matrix": "^1.2|^2.0",
+                "php": "^7.2|^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "require-dev": {
+                "dompdf/dompdf": "^0.8.5",
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "jpgraph/jpgraph": "^4.0",
+                "mpdf/mpdf": "^8.0",
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^8.5|^9.3",
+                "squizlabs/php_codesniffer": "^3.5",
+                "tecnickcom/tcpdf": "^6.3"
+            },
+            "suggest": {
+                "dompdf/dompdf": "Option for rendering PDF with PDF Writer (doesn't yet support PHP8)",
+                "jpgraph/jpgraph": "Option for rendering charts, or including charts with PDF or HTML Writers",
+                "mpdf/mpdf": "Option for rendering PDF with PDF Writer",
+                "tecnickcom/tcpdf": "Option for rendering PDF with PDF Writer (doesn't yet support PHP8)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpOffice\\PhpSpreadsheet\\": "src/PhpSpreadsheet"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maarten Balliauw",
+                    "homepage": "https://blog.maartenballiauw.be"
+                },
+                {
+                    "name": "Mark Baker",
+                    "homepage": "https://markbakeruk.net"
+                },
+                {
+                    "name": "Franck Lefevre",
+                    "homepage": "https://rootslabs.net"
+                },
+                {
+                    "name": "Erik Tilt"
+                },
+                {
+                    "name": "Adrien Crivelli"
+                }
+            ],
+            "description": "PHPSpreadsheet - Read, Create and Write Spreadsheet documents in PHP - Spreadsheet engine",
+            "homepage": "https://github.com/PHPOffice/PhpSpreadsheet",
+            "keywords": [
+                "OpenXML",
+                "excel",
+                "gnumeric",
+                "ods",
+                "php",
+                "spreadsheet",
+                "xls",
+                "xlsx"
+            ],
+            "time": "2020-10-11T13:20:59+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -5258,6 +5680,107 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2019-04-30T12:38:16+00:00"
         },
         {
             "name": "psr/http-message",
@@ -5355,6 +5878,54 @@
                 "psr-3"
             ],
             "time": "2020-03-23T09:12:05+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "psy/psysh",
@@ -5579,16 +6150,16 @@
         },
         {
             "name": "symfony/class-loader",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/class-loader.git",
-                "reference": "5e119b7df5e4db6fcd0570ea20f28e2bc57c3da2"
+                "reference": "a22265a9f3511c0212bf79f54910ca5a77c0e92c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/5e119b7df5e4db6fcd0570ea20f28e2bc57c3da2",
-                "reference": "5e119b7df5e4db6fcd0570ea20f28e2bc57c3da2",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/a22265a9f3511c0212bf79f54910ca5a77c0e92c",
+                "reference": "a22265a9f3511c0212bf79f54910ca5a77c0e92c",
                 "shasum": ""
             },
             "require": {
@@ -5602,11 +6173,6 @@
                 "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\ClassLoader\\": ""
@@ -5645,20 +6211,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T16:06:40+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "b28996bc0a3b08914b2a8609163ec35b36b30685"
+                "reference": "a10b1da6fc93080c180bba7219b5ff5b7518fe81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/b28996bc0a3b08914b2a8609163ec35b36b30685",
-                "reference": "b28996bc0a3b08914b2a8609163ec35b36b30685",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a10b1da6fc93080c180bba7219b5ff5b7518fe81",
+                "reference": "a10b1da6fc93080c180bba7219b5ff5b7518fe81",
                 "shasum": ""
             },
             "require": {
@@ -5688,11 +6254,6 @@
                 "symfony/process": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
@@ -5731,20 +6292,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-09T05:09:37+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v4.4.15",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "726b85e69342e767d60e3853b98559a68ff74183"
+                "reference": "c87adf3fc1cd0bf4758316a3a150d50a8f957ef4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/726b85e69342e767d60e3853b98559a68ff74183",
-                "reference": "726b85e69342e767d60e3853b98559a68ff74183",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/c87adf3fc1cd0bf4758316a3a150d50a8f957ef4",
+                "reference": "c87adf3fc1cd0bf4758316a3a150d50a8f957ef4",
                 "shasum": ""
             },
             "require": {
@@ -5759,11 +6320,6 @@
                 "symfony/http-kernel": "^3.4|^4.0|^5.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Debug\\": ""
@@ -5802,20 +6358,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-09T05:20:36+00:00"
+            "time": "2020-10-24T11:50:19+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "4199685e602129feb82b14279e774af05a4f5dc2"
+                "reference": "51d2a2708c6ceadad84393f8581df1dcf9e5e84b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/4199685e602129feb82b14279e774af05a4f5dc2",
-                "reference": "4199685e602129feb82b14279e774af05a4f5dc2",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/51d2a2708c6ceadad84393f8581df1dcf9e5e84b",
+                "reference": "51d2a2708c6ceadad84393f8581df1dcf9e5e84b",
                 "shasum": ""
             },
             "require": {
@@ -5844,11 +6400,6 @@
                 "symfony/yaml": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\DependencyInjection\\": ""
@@ -5887,20 +6438,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T12:07:49+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "0bb9ea263b39fce3a12ac9f78ef576bdd80dacb8"
+                "reference": "31fde73757b6bad247c54597beef974919ec6860"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0bb9ea263b39fce3a12ac9f78ef576bdd80dacb8",
-                "reference": "0bb9ea263b39fce3a12ac9f78ef576bdd80dacb8",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/31fde73757b6bad247c54597beef974919ec6860",
+                "reference": "31fde73757b6bad247c54597beef974919ec6860",
                 "shasum": ""
             },
             "require": {
@@ -5922,11 +6473,6 @@
                 "symfony/http-kernel": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
@@ -5965,20 +6511,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-18T12:06:50+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.4.15",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "ebc51494739d3b081ea543ed7c462fa73a4f74db"
+                "reference": "e74b873395b7213d44d1397bd4a605cd1632a68a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ebc51494739d3b081ea543ed7c462fa73a4f74db",
-                "reference": "ebc51494739d3b081ea543ed7c462fa73a4f74db",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e74b873395b7213d44d1397bd4a605cd1632a68a",
+                "reference": "e74b873395b7213d44d1397bd4a605cd1632a68a",
                 "shasum": ""
             },
             "require": {
@@ -5986,11 +6532,6 @@
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
@@ -6029,31 +6570,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-27T13:54:16+00:00"
+            "time": "2020-10-24T11:50:19+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.4.15",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "60d08560f9aa72997c44077c40d47aa28a963230"
+                "reference": "26f63b8d4e92f2eecd90f6791a563ebb001abe31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/60d08560f9aa72997c44077c40d47aa28a963230",
-                "reference": "60d08560f9aa72997c44077c40d47aa28a963230",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/26f63b8d4e92f2eecd90f6791a563ebb001abe31",
+                "reference": "26f63b8d4e92f2eecd90f6791a563ebb001abe31",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
@@ -6092,20 +6628,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-02T07:34:48+00:00"
+            "time": "2020-10-24T11:50:19+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "2264e389995997d2786c1eeb0a45db8e77dac132"
+                "reference": "b9885fcce6fe494201da4f70a9309770e9d13dc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/2264e389995997d2786c1eeb0a45db8e77dac132",
-                "reference": "2264e389995997d2786c1eeb0a45db8e77dac132",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b9885fcce6fe494201da4f70a9309770e9d13dc8",
+                "reference": "b9885fcce6fe494201da4f70a9309770e9d13dc8",
                 "shasum": ""
             },
             "require": {
@@ -6117,11 +6653,6 @@
                 "symfony/expression-language": "~2.8|~3.0|~4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\HttpFoundation\\": ""
@@ -6160,20 +6691,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-12T20:41:00+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "1f09d9eec88dd6d141f4d37751bc035da6a47418"
+                "reference": "09f8e3f9eb6d1c0e08abb0c9ad7d02f93b1d633d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1f09d9eec88dd6d141f4d37751bc035da6a47418",
-                "reference": "1f09d9eec88dd6d141f4d37751bc035da6a47418",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/09f8e3f9eb6d1c0e08abb0c9ad7d02f93b1d633d",
+                "reference": "09f8e3f9eb6d1c0e08abb0c9ad7d02f93b1d633d",
                 "shasum": ""
             },
             "require": {
@@ -6221,11 +6752,6 @@
                 "symfony/var-dumper": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\HttpKernel\\": ""
@@ -6264,24 +6790,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-27T03:46:58+00:00"
+            "time": "2020-10-28T05:40:17+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -6289,7 +6815,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6340,24 +6866,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36"
+                "reference": "c536646fdb4f29104dd26effc2fdcb9a5b085024"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36",
-                "reference": "6c2f78eb8f5ab8eaea98f6d414a5915f2e0fce36",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/c536646fdb4f29104dd26effc2fdcb9a5b085024",
+                "reference": "c536646fdb4f29104dd26effc2fdcb9a5b085024",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-iconv": "For best performance"
@@ -6365,7 +6891,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6417,26 +6943,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "5dcab1bc7146cf8c1beaa4502a3d9be344334251"
+                "reference": "3b75acd829741c768bc8b1f84eb33265e7cc5117"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/5dcab1bc7146cf8c1beaa4502a3d9be344334251",
-                "reference": "5dcab1bc7146cf8c1beaa4502a3d9be344334251",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/3b75acd829741c768bc8b1f84eb33265e7cc5117",
+                "reference": "3b75acd829741c768bc8b1f84eb33265e7cc5117",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
+                "php": ">=7.1",
                 "symfony/polyfill-intl-normalizer": "^1.10",
-                "symfony/polyfill-php70": "^1.10",
                 "symfony/polyfill-php72": "^1.10"
             },
             "suggest": {
@@ -6445,7 +6970,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6502,24 +7027,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-04T06:02:08+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e"
+                "reference": "727d1096295d807c309fb01a851577302394c897"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
-                "reference": "37078a8dd4a2a1e9ab0231af7c6cb671b2ed5a7e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/727d1096295d807c309fb01a851577302394c897",
+                "reference": "727d1096295d807c309fb01a851577302394c897",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -6527,7 +7052,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6583,24 +7108,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
-                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
+                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -6608,7 +7133,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6660,43 +7185,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "13df84e91cd168f247c2f2ec82cc0fa24901c011"
+                "reference": "54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/13df84e91cd168f247c2f2ec82cc0fa24901c011",
-                "reference": "13df84e91cd168f247c2f2ec82cc0fa24901c011",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675",
+                "reference": "54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "symfony/polyfill-util": "~1.0"
+                "php": ">=7.1"
             },
-            "type": "library",
+            "type": "metapackage",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
                 }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php56\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6734,46 +7250,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3"
+                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
-                "reference": "0dd93f2c578bdc9c72697eaa5f1dd25644e618d3",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/5f03a781d984aae42cebd18e7912fa80f02ee644",
+                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644",
                 "shasum": ""
             },
             "require": {
-                "paragonie/random_compat": "~1.0|~2.0|~9.99",
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
-            "type": "library",
+            "type": "metapackage",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
                     "url": "https://github.com/symfony/polyfill"
                 }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php70\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6811,29 +7315,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "639447d008615574653fb3bc60d1986d7172eaae"
+                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/639447d008615574653fb3bc60d1986d7172eaae",
-                "reference": "639447d008615574653fb3bc60d1986d7172eaae",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cede45fcdfabdd6043b3592e83678e42ec69e930",
+                "reference": "cede45fcdfabdd6043b3592e83678e42ec69e930",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6884,29 +7388,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.18.1",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981"
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/d87d5766cbf48d72388a9f6b85f280c8ad51f981",
-                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.8"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.18-dev"
+                    "dev-main": "1.20-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -6964,101 +7468,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-14T12:35:20+00:00"
-        },
-        {
-            "name": "symfony/polyfill-util",
-            "version": "v1.18.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "46b910c71e9828f8ec2aa7a0314de1130d9b295a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/46b910c71e9828f8ec2aa7a0314de1130d9b295a",
-                "reference": "46b910c71e9828f8ec2aa7a0314de1130d9b295a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.18-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Util\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony utilities for portability of PHP codes",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compat",
-                "compatibility",
-                "polyfill",
-                "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-07-14T12:35:20+00:00"
+            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "46a862d0f334e51c1ed831b49cbe12863ffd5475"
+                "reference": "b8648cf1d5af12a44a51d07ef9bf980921f15fca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/46a862d0f334e51c1ed831b49cbe12863ffd5475",
-                "reference": "46a862d0f334e51c1ed831b49cbe12863ffd5475",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b8648cf1d5af12a44a51d07ef9bf980921f15fca",
+                "reference": "b8648cf1d5af12a44a51d07ef9bf980921f15fca",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
@@ -7097,7 +7526,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T16:06:40+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
@@ -7166,16 +7595,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "9c62272ecc68d1a055ded693a5b47683300fa213"
+                "reference": "3e522ac69cadffd8131cc2b22157fa7662331a6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/9c62272ecc68d1a055ded693a5b47683300fa213",
-                "reference": "9c62272ecc68d1a055ded693a5b47683300fa213",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3e522ac69cadffd8131cc2b22157fa7662331a6c",
+                "reference": "3e522ac69cadffd8131cc2b22157fa7662331a6c",
                 "shasum": ""
             },
             "require": {
@@ -7203,11 +7632,6 @@
                 "symfony/yaml": "For using the YAML loader"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Routing\\": ""
@@ -7252,20 +7676,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T16:06:40+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "b7d9a52bb1b3ec606238feb645908ffc8b4f714f"
+                "reference": "6d69ccc1dcfb64c1e9c9444588643e98718d1849"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/b7d9a52bb1b3ec606238feb645908ffc8b4f714f",
-                "reference": "b7d9a52bb1b3ec606238feb645908ffc8b4f714f",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/6d69ccc1dcfb64c1e9c9444588643e98718d1849",
+                "reference": "6d69ccc1dcfb64c1e9c9444588643e98718d1849",
                 "shasum": ""
             },
             "require": {
@@ -7302,11 +7726,6 @@
                 "symfony/yaml": "For using the default YAML mapping loader."
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Serializer\\": ""
@@ -7345,20 +7764,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T16:06:40+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "c826cb2216d1627d1882e212d2ac3ac13d8d5b78"
+                "reference": "be83ee6c065cb32becdb306ba61160d598b1ce88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/c826cb2216d1627d1882e212d2ac3ac13d8d5b78",
-                "reference": "c826cb2216d1627d1882e212d2ac3ac13d8d5b78",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/be83ee6c065cb32becdb306ba61160d598b1ce88",
+                "reference": "be83ee6c065cb32becdb306ba61160d598b1ce88",
                 "shasum": ""
             },
             "require": {
@@ -7386,11 +7805,6 @@
                 "symfony/yaml": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Translation\\": ""
@@ -7429,20 +7843,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-02T16:06:40+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "symfony/validator",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "491955de926e547fc6a3c32b982099d7db7ea3a8"
+                "reference": "d25ceea5c99022aecf37adf157c76c31fc5dcbed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/491955de926e547fc6a3c32b982099d7db7ea3a8",
-                "reference": "491955de926e547fc6a3c32b982099d7db7ea3a8",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/d25ceea5c99022aecf37adf157c76c31fc5dcbed",
+                "reference": "d25ceea5c99022aecf37adf157c76c31fc5dcbed",
                 "shasum": ""
             },
             "require": {
@@ -7486,11 +7900,6 @@
                 "symfony/yaml": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Validator\\": ""
@@ -7529,20 +7938,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-22T08:56:57+00:00"
+            "time": "2020-10-28T05:23:51+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v4.4.15",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "0dc22bdf9d1197467bb04d505355180b6f20bcca"
+                "reference": "3718e18b68d955348ad860e505991802c09f5f73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0dc22bdf9d1197467bb04d505355180b6f20bcca",
-                "reference": "0dc22bdf9d1197467bb04d505355180b6f20bcca",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/3718e18b68d955348ad860e505991802c09f5f73",
+                "reference": "3718e18b68d955348ad860e505991802c09f5f73",
                 "shasum": ""
             },
             "require": {
@@ -7570,11 +7979,6 @@
                 "Resources/bin/var-dump-server"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "Resources/functions/dump.php"
@@ -7620,20 +8024,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-18T08:35:10+00:00"
+            "time": "2020-10-26T20:47:51+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "ec3c2ac4d881a4684c1f0317d2107f1a4152bad9"
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ec3c2ac4d881a4684c1f0317d2107f1a4152bad9",
-                "reference": "ec3c2ac4d881a4684c1f0317d2107f1a4152bad9",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
+                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
                 "shasum": ""
             },
             "require": {
@@ -7650,11 +8054,6 @@
                 "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
@@ -7693,20 +8092,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-18T15:58:55+00:00"
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v1.44.0",
+            "version": "v1.44.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "e7c93a4af5eba2b0b3cf51d540e0a131187d7410"
+                "reference": "04b15d4c0bb18ddbf82626320ac07f6a73f199c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/e7c93a4af5eba2b0b3cf51d540e0a131187d7410",
-                "reference": "e7c93a4af5eba2b0b3cf51d540e0a131187d7410",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04b15d4c0bb18ddbf82626320ac07f6a73f199c9",
+                "reference": "04b15d4c0bb18ddbf82626320ac07f6a73f199c9",
                 "shasum": ""
             },
             "require": {
@@ -7767,7 +8166,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-21T12:32:35+00:00"
+            "time": "2020-10-27T19:22:48+00:00"
         },
         {
             "name": "typo3/phar-stream-wrapper",
@@ -7875,16 +8274,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v2.8.3",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "e3504beb62a5385e165d566bd46e646e98589882"
+                "reference": "1cff3c7ba158366ca82588af2bdd98b3afa81fa4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/e3504beb62a5385e165d566bd46e646e98589882",
-                "reference": "e3504beb62a5385e165d566bd46e646e98589882",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/1cff3c7ba158366ca82588af2bdd98b3afa81fa4",
+                "reference": "1cff3c7ba158366ca82588af2bdd98b3afa81fa4",
                 "shasum": ""
             },
             "require": {
@@ -7895,20 +8294,20 @@
             "license": [
                 "GPL-2.0-only"
             ],
-            "time": "2020-08-20T12:46:02+00:00"
+            "time": "2020-10-22T08:41:56+00:00"
         },
         {
             "name": "webflo/drupal-finder",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webflo/drupal-finder.git",
-                "reference": "123e248e14ee8dd3fbe89fb5a733a6cf91f5820e"
+                "reference": "c8e5dbe65caef285fec8057a4c718a0d4138d1ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webflo/drupal-finder/zipball/123e248e14ee8dd3fbe89fb5a733a6cf91f5820e",
-                "reference": "123e248e14ee8dd3fbe89fb5a733a6cf91f5820e",
+                "url": "https://api.github.com/repos/webflo/drupal-finder/zipball/c8e5dbe65caef285fec8057a4c718a0d4138d1ee",
+                "reference": "c8e5dbe65caef285fec8057a4c718a0d4138d1ee",
                 "shasum": ""
             },
             "require": {
@@ -7926,7 +8325,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -7935,7 +8334,7 @@
                 }
             ],
             "description": "Helper class to locate a Drupal installation from a given path.",
-            "time": "2019-08-02T08:06:18+00:00"
+            "time": "2020-10-27T09:42:17+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -8034,20 +8433,20 @@
         },
         {
             "name": "zaporylie/composer-drupal-optimizations",
-            "version": "1.1.2",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zaporylie/composer-drupal-optimizations.git",
-                "reference": "0d6ebd8bc03679d312f99a1e4e950685dbf0ff18"
+                "reference": "a7f409a765164fd13ac0bd00e19109165c51b369"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zaporylie/composer-drupal-optimizations/zipball/0d6ebd8bc03679d312f99a1e4e950685dbf0ff18",
-                "reference": "0d6ebd8bc03679d312f99a1e4e950685dbf0ff18",
+                "url": "https://api.github.com/repos/zaporylie/composer-drupal-optimizations/zipball/a7f409a765164fd13ac0bd00e19109165c51b369",
+                "reference": "a7f409a765164fd13ac0bd00e19109165c51b369",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1"
+                "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
                 "composer/composer": "^1.6",
@@ -8073,7 +8472,7 @@
                 }
             ],
             "description": "Composer plugin to improve composer performance for Drupal projects",
-            "time": "2020-10-06T10:41:00+00:00"
+            "time": "2020-10-22T13:26:00+00:00"
         }
     ],
     "packages-dev": [
@@ -8316,16 +8715,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.3",
+            "version": "1.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "ebd27a9866ae8254e873866f795491f02418c5a5"
+                "reference": "6e076a124f7ee146f2487554a94b6a19a74887ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ebd27a9866ae8254e873866f795491f02418c5a5",
-                "reference": "ebd27a9866ae8254e873866f795491f02418c5a5",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6e076a124f7ee146f2487554a94b6a19a74887ba",
+                "reference": "6e076a124f7ee146f2487554a94b6a19a74887ba",
                 "shasum": ""
             },
             "require": {
@@ -8370,7 +8769,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-19T10:27:58+00:00"
+            "time": "2020-10-24T12:39:10+00:00"
         },
         {
             "name": "dflydev/dot-access-configuration",
@@ -10601,16 +11000,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.6",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
-                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -10648,7 +11047,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-08-10T04:50:15+00:00"
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "stecman/symfony-console-completion",
@@ -10697,16 +11096,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v4.4.15",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "9a1786e5020783605a30cff2ceed9aca030e8d80"
+                "reference": "99b640fd5d06877e3242ba0393b40a7877dfe534"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/9a1786e5020783605a30cff2ceed9aca030e8d80",
-                "reference": "9a1786e5020783605a30cff2ceed9aca030e8d80",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/99b640fd5d06877e3242ba0393b40a7877dfe534",
+                "reference": "99b640fd5d06877e3242ba0393b40a7877dfe534",
                 "shasum": ""
             },
             "require": {
@@ -10723,11 +11122,6 @@
                 "symfony/process": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\BrowserKit\\": ""
@@ -10766,20 +11160,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-02T08:38:15+00:00"
+            "time": "2020-10-24T11:50:19+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v4.4.15",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "7c5a1002178a612787c291a4f515f87b19176b61"
+                "reference": "e85481cf359a7b28a44ac91f7d83441b70d76192"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/7c5a1002178a612787c291a4f515f87b19176b61",
-                "reference": "7c5a1002178a612787c291a4f515f87b19176b61",
+                "url": "https://api.github.com/repos/symfony/config/zipball/e85481cf359a7b28a44ac91f7d83441b70d76192",
+                "reference": "e85481cf359a7b28a44ac91f7d83441b70d76192",
                 "shasum": ""
             },
             "require": {
@@ -10801,11 +11195,6 @@
                 "symfony/yaml": "To use the yaml reference dumper"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Config\\": ""
@@ -10844,31 +11233,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-02T07:34:48+00:00"
+            "time": "2020-10-24T11:50:19+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.4.15",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "bf17dc9f6ce144e41f786c32435feea4d8e11dcc"
+                "reference": "719506cffda9dba80c75d94ac50f1a2561520e4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/bf17dc9f6ce144e41f786c32435feea4d8e11dcc",
-                "reference": "bf17dc9f6ce144e41f786c32435feea4d8e11dcc",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/719506cffda9dba80c75d94ac50f1a2561520e4f",
+                "reference": "719506cffda9dba80c75d94ac50f1a2561520e4f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.3"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\CssSelector\\": ""
@@ -10911,20 +11295,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-05T09:39:30+00:00"
+            "time": "2020-10-24T11:50:19+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v4.4.15",
+            "version": "v4.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "bdcb7633a501770a0daefbf81d2e6b28c3864f2b"
+                "reference": "30ad9ac96a01913195bf0328d48e29d54fa53e6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/bdcb7633a501770a0daefbf81d2e6b28c3864f2b",
-                "reference": "bdcb7633a501770a0daefbf81d2e6b28c3864f2b",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/30ad9ac96a01913195bf0328d48e29d54fa53e6e",
+                "reference": "30ad9ac96a01913195bf0328d48e29d54fa53e6e",
                 "shasum": ""
             },
             "require": {
@@ -10943,11 +11327,6 @@
                 "symfony/css-selector": ""
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\DomCrawler\\": ""
@@ -10986,7 +11365,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-02T07:34:48+00:00"
+            "time": "2020-10-24T11:50:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/core.entity_form_display.paragraph.needs_and_requirements.default.yml
+++ b/config/core.entity_form_display.paragraph.needs_and_requirements.default.yml
@@ -1,0 +1,21 @@
+uuid: 380f691d-1f81-4e43-9b53-a23ad1b3d6c3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.needs_and_requirements.field_needs_and_requirements
+    - paragraphs.paragraphs_type.needs_and_requirements
+id: paragraph.needs_and_requirements.default
+targetEntityType: paragraph
+bundle: needs_and_requirements
+mode: default
+content:
+  field_needs_and_requirements:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.needs_and_requirements.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.needs_and_requirements.default.yml
@@ -1,0 +1,68 @@
+uuid: 939b8970-f453-4faf-8dc1-3a882cdb9c15
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.needs_and_requirements.field_people_in_need
+    - field.field.taxonomy_term.needs_and_requirements.field_people_targeted
+    - field.field.taxonomy_term.needs_and_requirements.field_requirements
+    - taxonomy.vocabulary.needs_and_requirements
+  module:
+    - allowed_formats
+    - bigint
+    - text
+id: taxonomy_term.needs_and_requirements.default
+targetEntityType: taxonomy_term
+bundle: needs_and_requirements
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
+  field_people_in_need:
+    weight: 2
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: bigint
+    region: content
+  field_people_targeted:
+    weight: 3
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: bigint
+    region: content
+  field_requirements:
+    weight: 4
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: bigint
+    region: content
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 5
+    region: content
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true

--- a/config/core.entity_view_display.node.article.related_article.yml
+++ b/config/core.entity_view_display.node.article.related_article.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.related_article
+    - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_further_reading
     - field.field.node.article.field_hero_image

--- a/config/core.entity_view_display.paragraph.needs_and_requirements.default.yml
+++ b/config/core.entity_view_display.paragraph.needs_and_requirements.default.yml
@@ -1,0 +1,22 @@
+uuid: 62ba94a5-213c-4bcc-89e3-6b7abda05b97
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.needs_and_requirements.field_needs_and_requirements
+    - paragraphs.paragraphs_type.needs_and_requirements
+id: paragraph.needs_and_requirements.default
+targetEntityType: paragraph
+bundle: needs_and_requirements
+mode: default
+content:
+  field_needs_and_requirements:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden: {  }

--- a/config/core.entity_view_display.taxonomy_term.needs_and_requirements.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.needs_and_requirements.default.yml
@@ -1,0 +1,46 @@
+uuid: 7b587dba-b917-4707-94c0-7585fc1d6420
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.needs_and_requirements.field_people_in_need
+    - field.field.taxonomy_term.needs_and_requirements.field_people_targeted
+    - field.field.taxonomy_term.needs_and_requirements.field_requirements
+    - taxonomy.vocabulary.needs_and_requirements
+  module:
+    - gho_fields
+id: taxonomy_term.needs_and_requirements.default
+targetEntityType: taxonomy_term
+bundle: needs_and_requirements
+mode: default
+content:
+  field_people_in_need:
+    weight: -4
+    label: above
+    settings:
+      format: long
+      precision: 2
+    third_party_settings: {  }
+    type: gho_number
+    region: content
+  field_people_targeted:
+    weight: -3
+    label: above
+    settings:
+      format: long
+      precision: 2
+    third_party_settings: {  }
+    type: gho_number
+    region: content
+  field_requirements:
+    weight: -2
+    label: above
+    settings:
+      format: long
+      precision: 1
+    third_party_settings: {  }
+    type: gho_number
+    region: content
+hidden:
+  description: true
+  langcode: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -1,6 +1,7 @@
 module:
   admin_denied: 0
   allowed_formats: 0
+  bigint: 0
   block: 0
   breakpoint: 0
   ckeditor: 0
@@ -23,6 +24,7 @@ module:
   filter: 0
   gho_access: 0
   gho_fields: 0
+  gho_figures: 0
   gho_footnotes: 0
   gho_general: 0
   gho_layouts: 0

--- a/config/field.field.node.article.field_paragraphs.yml
+++ b/config/field.field.node.article.field_paragraphs.yml
@@ -5,13 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_paragraphs
     - node.type.article
-    - paragraphs.paragraphs_type.bottom_figure_row
-    - paragraphs.paragraphs_type.facts_and_figures
-    - paragraphs.paragraphs_type.layout
-    - paragraphs.paragraphs_type.photo_gallery
-    - paragraphs.paragraphs_type.separator
-    - paragraphs.paragraphs_type.story
-    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.image_with_text
   module:
     - entity_reference_revisions
 id: node.article.field_paragraphs
@@ -27,38 +21,35 @@ default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
-    negate: 0
+    negate: 1
     target_bundles:
-      bottom_figure_row: bottom_figure_row
-      layout: layout
-      facts_and_figures: facts_and_figures
-      story: story
-      text: text
-      photo_gallery: photo_gallery
-      separator: separator
+      image_with_text: image_with_text
     target_bundles_drag_drop:
       bottom_figure_row:
-        enabled: true
         weight: 8
-      facts_and_figures:
-        enabled: true
-        weight: 9
-      image_with_text:
-        weight: 12
         enabled: false
+      facts_and_figures:
+        weight: 9
+        enabled: false
+      image_with_text:
+        enabled: true
+        weight: 12
       layout:
-        enabled: true
         weight: 8
+        enabled: false
+      needs_and_requirements:
+        weight: 14
+        enabled: false
       photo_gallery:
-        enabled: true
         weight: 11
+        enabled: false
       separator:
-        enabled: true
         weight: 15
+        enabled: false
       story:
-        enabled: true
         weight: 10
+        enabled: false
       text:
-        enabled: true
         weight: 10
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/field.field.paragraph.needs_and_requirements.field_needs_and_requirements.yml
+++ b/config/field.field.paragraph.needs_and_requirements.field_needs_and_requirements.yml
@@ -1,0 +1,29 @@
+uuid: 25b98a12-1580-44ee-adf9-d1ef2fc35722
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_needs_and_requirements
+    - paragraphs.paragraphs_type.needs_and_requirements
+    - taxonomy.vocabulary.needs_and_requirements
+id: paragraph.needs_and_requirements.field_needs_and_requirements
+field_name: field_needs_and_requirements
+entity_type: paragraph
+bundle: needs_and_requirements
+label: 'Needs and requirements figures'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      needs_and_requirements: needs_and_requirements
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.taxonomy_term.needs_and_requirements.field_people_in_need.yml
+++ b/config/field.field.taxonomy_term.needs_and_requirements.field_people_in_need.yml
@@ -1,0 +1,25 @@
+uuid: 8bb4489f-a0e6-4c51-8118-77657882e32c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_people_in_need
+    - taxonomy.vocabulary.needs_and_requirements
+  module:
+    - bigint
+id: taxonomy_term.needs_and_requirements.field_people_in_need
+field_name: field_people_in_need
+entity_type: taxonomy_term
+bundle: needs_and_requirements
+label: 'People in need'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: bigint

--- a/config/field.field.taxonomy_term.needs_and_requirements.field_people_targeted.yml
+++ b/config/field.field.taxonomy_term.needs_and_requirements.field_people_targeted.yml
@@ -1,0 +1,25 @@
+uuid: d3a413ce-2072-418f-9c94-b91279cc0275
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_people_targeted
+    - taxonomy.vocabulary.needs_and_requirements
+  module:
+    - bigint
+id: taxonomy_term.needs_and_requirements.field_people_targeted
+field_name: field_people_targeted
+entity_type: taxonomy_term
+bundle: needs_and_requirements
+label: 'People targeted'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: bigint

--- a/config/field.field.taxonomy_term.needs_and_requirements.field_requirements.yml
+++ b/config/field.field.taxonomy_term.needs_and_requirements.field_requirements.yml
@@ -1,0 +1,25 @@
+uuid: 4dffdd79-9c22-48a3-bfa2-8916e74a4645
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_requirements
+    - taxonomy.vocabulary.needs_and_requirements
+  module:
+    - bigint
+id: taxonomy_term.needs_and_requirements.field_requirements
+field_name: field_requirements
+entity_type: taxonomy_term
+bundle: needs_and_requirements
+label: 'Requirements (US$)'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 0
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: bigint

--- a/config/field.storage.paragraph.field_needs_and_requirements.yml
+++ b/config/field.storage.paragraph.field_needs_and_requirements.yml
@@ -1,0 +1,20 @@
+uuid: 3a0cd653-a6d1-49ef-8ea3-0ff0e718666f
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_needs_and_requirements
+field_name: field_needs_and_requirements
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_people_in_need.yml
+++ b/config/field.storage.taxonomy_term.field_people_in_need.yml
@@ -1,0 +1,21 @@
+uuid: 16042545-cd3d-4b96-8699-7563c23506cf
+langcode: en
+status: true
+dependencies:
+  module:
+    - bigint
+    - taxonomy
+id: taxonomy_term.field_people_in_need
+field_name: field_people_in_need
+entity_type: taxonomy_term
+type: bigint
+settings:
+  unsigned: true
+  size: big
+module: bigint
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_people_targeted.yml
+++ b/config/field.storage.taxonomy_term.field_people_targeted.yml
@@ -1,0 +1,21 @@
+uuid: 9644d31f-bba0-4475-a47d-0c694db3d0d0
+langcode: en
+status: true
+dependencies:
+  module:
+    - bigint
+    - taxonomy
+id: taxonomy_term.field_people_targeted
+field_name: field_people_targeted
+entity_type: taxonomy_term
+type: bigint
+settings:
+  unsigned: true
+  size: big
+module: bigint
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.taxonomy_term.field_requirements.yml
+++ b/config/field.storage.taxonomy_term.field_requirements.yml
@@ -1,0 +1,21 @@
+uuid: 20ff4ac4-bc38-46b2-bfc2-003f863eec2f
+langcode: en
+status: true
+dependencies:
+  module:
+    - bigint
+    - taxonomy
+id: taxonomy_term.field_requirements
+field_name: field_requirements
+entity_type: taxonomy_term
+type: bigint
+settings:
+  unsigned: true
+  size: big
+module: bigint
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/filter.format.footnotes.yml
+++ b/config/filter.format.footnotes.yml
@@ -23,12 +23,3 @@ filters:
     status: true
     weight: 10
     settings: {  }
-  media_embed:
-    id: media_embed
-    provider: media
-    status: false
-    weight: 100
-    settings:
-      default_view_mode: default
-      allowed_media_types: {  }
-      allowed_view_modes: {  }

--- a/config/language.content_settings.taxonomy_term.needs_and_requirements.yml
+++ b/config/language.content_settings.taxonomy_term.needs_and_requirements.yml
@@ -1,0 +1,11 @@
+uuid: 0f282c44-5f81-4132-9735-2d8710590257
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.needs_and_requirements
+id: taxonomy_term.needs_and_requirements
+target_entity_type_id: taxonomy_term
+target_bundle: needs_and_requirements
+default_langcode: site_default
+language_alterable: false

--- a/config/paragraphs.paragraphs_type.needs_and_requirements.yml
+++ b/config/paragraphs.paragraphs_type.needs_and_requirements.yml
@@ -1,0 +1,10 @@
+uuid: fbe84756-25b4-41fe-a604-00e8221b391a
+langcode: en
+status: true
+dependencies: {  }
+id: needs_and_requirements
+label: 'Needs and requirements'
+icon_uuid: null
+icon_default: null
+description: 'A paragraph showing needs and requirements figures (people in need, people targeted and requirements (US$)).'
+behavior_plugins: {  }

--- a/config/taxonomy.vocabulary.needs_and_requirements.yml
+++ b/config/taxonomy.vocabulary.needs_and_requirements.yml
@@ -1,0 +1,8 @@
+uuid: 85921d1f-f317-4e9d-9014-a4a36e85f5ef
+langcode: en
+status: true
+dependencies: {  }
+name: 'Needs and requirements'
+vid: needs_and_requirements
+description: 'Figures (people in need, people targeted, funding requirements) for the global and regional overviews and appeals'
+weight: 0

--- a/config/views.view.needs_and_requirements.yml
+++ b/config/views.view.needs_and_requirements.yml
@@ -1,0 +1,629 @@
+uuid: 840ecb0e-425c-463f-8cc9-0e39b4ff4da7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_people_in_need
+    - field.storage.taxonomy_term.field_people_targeted
+    - field.storage.taxonomy_term.field_requirements
+    - taxonomy.vocabulary.needs_and_requirements
+  module:
+    - bigint
+    - taxonomy
+    - user
+id: needs_and_requirements
+label: 'Needs and requirements'
+module: views
+description: 'List overviews and appeals and their needs and requirements'
+tag: ''
+base_table: taxonomy_term_field_data
+base_field: tid
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access taxonomy overview'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 50
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            name: name
+            status: status
+            field_people_in_need: field_people_in_need
+            field_people_targeted: field_people_targeted
+            field_requirements: field_requirements
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_people_in_need:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_people_targeted:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_requirements:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: name
+          empty_table: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+        field_people_in_need:
+          id: field_people_in_need
+          table: taxonomy_term__field_people_in_need
+          field: field_people_in_need
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'People in need'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: bigint_item_default
+          settings:
+            thousand_separator: ','
+            prefix_suffix: 1
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_people_targeted:
+          id: field_people_targeted
+          table: taxonomy_term__field_people_targeted
+          field: field_people_targeted
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'People targeted'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: bigint_item_default
+          settings:
+            thousand_separator: ','
+            prefix_suffix: 1
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_requirements:
+          id: field_requirements
+          table: taxonomy_term__field_requirements
+          field: field_requirements
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Requirements (US$)'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: bigint_item_default
+          settings:
+            thousand_separator: ','
+            prefix_suffix: 1
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        status:
+          id: status
+          table: taxonomy_term_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Published
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: boolean
+          settings:
+            format: yes-no
+            format_custom_true: ''
+            format_custom_false: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: taxonomy_term
+          entity_field: status
+          plugin_id: field
+        changed:
+          id: changed
+          table: taxonomy_term_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: short
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: taxonomy_term
+          entity_field: changed
+          plugin_id: field
+      filters:
+        status:
+          id: status
+          table: taxonomy_term_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Published
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+          entity_type: taxonomy_term
+          entity_field: status
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          value:
+            needs_and_requirements: needs_and_requirements
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      sorts: {  }
+      title: 'Needs and requirements'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:field.storage.taxonomy_term.field_people_in_need'
+        - 'config:field.storage.taxonomy_term.field_people_targeted'
+        - 'config:field.storage.taxonomy_term.field_requirements'
+  page_needs_and_requirements:
+    display_plugin: page
+    id: page_needs_and_requirements
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/content/needs-and-requirements
+      menu:
+        type: tab
+        title: 'Needs and requirements'
+        description: ''
+        expanded: false
+        parent: system.admin_content
+        weight: 10
+        context: '0'
+        menu_name: admin
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:field.storage.taxonomy_term.field_people_in_need'
+        - 'config:field.storage.taxonomy_term.field_people_targeted'
+        - 'config:field.storage.taxonomy_term.field_requirements'

--- a/html/modules/custom/gho_fields/config/schema/gho_fields.schema.yml
+++ b/html/modules/custom/gho_fields/config/schema/gho_fields.schema.yml
@@ -9,6 +9,16 @@ field.formatter.settings.gho_further_reading_link:
   label: 'GHO further reading link formatter settings'
   mapping:
     # No settings.
+field.formatter.settings.gho_number:
+  type: mapping
+  label: 'GHO number formatter settings'
+  mapping:
+    format:
+      type: string
+      label: 'Format'
+    precision:
+      type: integer
+      label: 'Precision'
 
 # Widgets.
 field.widget.settings.gho_dataset_link:

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoNumberFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoNumberFormatter.php
@@ -1,0 +1,565 @@
+<?php
+
+namespace Drupal\gho_fields\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\AllowedTagsXssTrait;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Plugin implementation of the 'gho_number' formatter.
+ *
+ * Language aware number formatter with 3 formats:
+ * - decimal with grouped thousands (ex: 1,200,000)
+ * - compact - long (ex: 1.2 million)
+ * - compact - short (ex: 1.2M)
+ *
+ * @FieldFormatter(
+ *   id = "gho_number",
+ *   label = @Translation("GHO number"),
+ *   field_types = {
+ *     "int",
+ *     "float",
+ *     "bigint"
+ *   }
+ * )
+ */
+class GhoNumberFormatter extends FormatterBase {
+
+  // Trait used to filter the prefix/suffix.
+  use AllowedTagsXssTrait;
+
+  /**
+   * Patterns for the long and short compact number formatting.
+   *
+   * Note: we are only interested in powers of 1000 and only support Arabic,
+   * English, French and Spanish so the values here reflect that.
+   *
+   * @var array
+   *
+   * @see https://github.com/twitter/twitter-cldr-js/blob/master/lib/assets/javascripts/twitter_cldr/ar.js
+   * @see https://github.com/twitter/twitter-cldr-js/blob/master/lib/assets/javascripts/twitter_cldr/en.js
+   * @see https://github.com/twitter/twitter-cldr-js/blob/master/lib/assets/javascripts/twitter_cldr/es.js
+   * @see https://github.com/twitter/twitter-cldr-js/blob/master/lib/assets/javascripts/twitter_cldr/fr.js
+   *
+   * @see https://unicode-org.github.io/cldr-staging/charts/38/supplemental/language_plural_rules.html#ar
+   * @see https://unicode-org.github.io/cldr-staging/charts/38/supplemental/language_plural_rules.html#en
+   * @see https://unicode-org.github.io/cldr-staging/charts/38/supplemental/language_plural_rules.html#es
+   * @see https://unicode-org.github.io/cldr-staging/charts/38/supplemental/language_plural_rules.html#fr
+   */
+  protected $patterns = [
+    // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/ar.html
+    "ar" => [
+      "long" => [
+        "1000" => [
+          "few" => "0 آلاف",
+          "many" => "0 ألف",
+          "one" => "0 ألف",
+          "other" => "0 ألف",
+          "two" => "0 ألف",
+          "zero" => "0 ألف",
+        ],
+        "1000000" => [
+          "few" => "0 ملايين",
+          "many" => "0 مليون",
+          "one" => "0 مليون",
+          "other" => "0 مليون",
+          "two" => "0 مليون",
+          "zero" => "0 مليون",
+        ],
+        "1000000000" => [
+          "few" => "0 بلايين",
+          "many" => "0 بليون",
+          "one" => "0 بليون",
+          "other" => "0 بليون",
+          "two" => "0 بليون",
+          "zero" => "0 بليون",
+        ],
+        "1000000000000" => [
+          "few" => "0 تريليونات",
+          "many" => "0 تريليون",
+          "one" => "0 تريليون",
+          "other" => "0 تريليون",
+          "two" => "0 تريليون",
+          "zero" => "0 تريليون",
+        ],
+      ],
+      "short" => [
+        "1000" => [
+          "few" => "0 آلاف",
+          "many" => "0 ألف",
+          "one" => "0 ألف",
+          "other" => "0 ألف",
+          "two" => "0 ألف",
+          "zero" => "0 ألف",
+        ],
+        "1000000" => [
+          "few" => "0 مليو",
+          "many" => "0 مليو",
+          "one" => "0 مليو",
+          "other" => "0 مليو",
+          "two" => "0 مليو",
+          "zero" => "0 مليو",
+        ],
+        "1000000000" => [
+          "few" => "0 بليو",
+          "many" => "0 بليو",
+          "one" => "0 بليو",
+          "other" => "0 بليو",
+          "two" => "0 بليو",
+          "zero" => "0 بليو",
+        ],
+        "1000000000000" => [
+          "few" => "0 ترليو",
+          "many" => "0 ترليو",
+          "one" => "0 ترليو",
+          "other" => "0 ترليو",
+          "two" => "0 ترليو",
+          "zero" => "0 ترليو",
+        ],
+      ],
+    ],
+    // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/en.html
+    "en" => [
+      "long" => [
+        "1000" => [
+          "one" => "0 thousand",
+          "other" => "0 thousand",
+        ],
+        "1000000" => [
+          "one" => "0 million",
+          "other" => "0 million",
+        ],
+        "1000000000" => [
+          "one" => "0 billion",
+          "other" => "0 billion",
+        ],
+        "1000000000000" => [
+          "one" => "0 trillion",
+          "other" => "0 trillion",
+        ],
+      ],
+      "short" => [
+        "1000" => [
+          "one" => "0K",
+          "other" => "0K",
+        ],
+        "1000000" => [
+          "one" => "0M",
+          "other" => "0M",
+        ],
+        "1000000000" => [
+          "one" => "0B",
+          "other" => "0B",
+        ],
+        "1000000000000" => [
+          "one" => "0T",
+          "other" => "0T",
+        ],
+      ],
+    ],
+    // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/es.html
+    "es" => [
+      "long" => [
+        "1000" => [
+          "one" => "0 mil",
+          "other" => "0 mil",
+        ],
+        "1000000" => [
+          "one" => "0 millón",
+          "other" => "0 millones",
+        ],
+        "1000000000" => [
+          "one" => "0 mil millones",
+          "other" => "0 mil millones",
+        ],
+        "1000000000000" => [
+          "one" => "0 billón",
+          "other" => "0 billones",
+        ],
+      ],
+      "short" => [
+        "1000" => [
+          "one" => "0K",
+          "other" => "0K",
+        ],
+        "1000000" => [
+          "one" => "0M",
+          "other" => "0M",
+        ],
+        "1000000000" => [
+          "one" => "0000M",
+          "other" => "0000M",
+        ],
+        "1000000000000" => [
+          "one" => "0B",
+          "other" => "0B",
+        ],
+      ],
+    ],
+    // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/fr.html
+    "fr" => [
+      "long" => [
+        "1000" => [
+          "one" => "0 millier",
+          "other" => "0 mille",
+        ],
+        "1000000" => [
+          "one" => "0 million",
+          "other" => "0 millions",
+        ],
+        "1000000000" => [
+          "one" => "0 milliard",
+          "other" => "0 milliards",
+        ],
+        "1000000000000" => [
+          "one" => "0 billion",
+          "other" => "0 billions",
+        ],
+      ],
+      "short" => [
+        "1000" => [
+          "one" => "0 k",
+          "other" => "0 k",
+        ],
+        "1000000" => [
+          "one" => "0 M",
+          "other" => "0 M",
+        ],
+        "1000000000" => [
+          "one" => "0 Md",
+          "other" => "0 Md",
+        ],
+        "1000000000000" => [
+          "one" => "0 Bn",
+          "other" => "0 Bn",
+        ],
+      ],
+    ],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'format' => 'decimal',
+      'precision' => 1,
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $options = [
+      'decimal' => $this->t('Thousand marker (ex: 1,200,000)'),
+      'long' => $this->t('Compact - Long (ex: 1.2 million)'),
+      'short' => $this->t('Compact - Short (ex: 1.2M)'),
+    ];
+    $elements['format'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Format'),
+      '#options' => $options,
+      '#default_value' => $this->getSetting('format') ?? 'decimal',
+    ];
+    $elements['precision'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Precision'),
+      '#descripion' => $this->t('Number of decimal digits in compact form: 1.2 million with a precision of 1, 1.23 million with a precision of 2.'),
+      '#options' => [
+        '1' => 1,
+        '2' => 2,
+        '3' => 3,
+        '4' => 4,
+        '5' => 5,
+      ],
+      '#default_value' => $this->getSetting('precision') ?? '1',
+      '#states' => [
+        'visible' => [
+          'select[name$="[settings][format]"]' => [
+            ['value' => 'long'],
+            ['value' => 'short'],
+          ],
+        ],
+      ],
+    ];
+    return $elements;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $summary = [];
+
+    $format = $this->getSetting('format') ?? 'decimal';
+    $summary[] = $this->t('Format: @format', ['@format' => $format]);
+    if ($format === 'short' || $format === 'long') {
+      $summary[] = $this->t('Precision: @precision', [
+        '@precision' => $this->getSetting('precision') ?? 1,
+      ]);
+    }
+    $summary[] = $this->t('Example: @example', [
+      '@example' => $this->formatNumber(12300000, 'en'),
+    ]);
+
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+
+    foreach ($items as $delta => $item) {
+      $element[$delta] = [
+        '#markup' => $this->formatNumber($item->value, $langcode),
+      ];
+      // Store the raw value to be displayed as an attribute on the item
+      // wrapper.
+      $items->_attributes += ['data-raw' => $item->value];
+    }
+
+    return $element;
+  }
+
+  /**
+   * Format a number according to the settings.
+   *
+   * @param float|int $number
+   *   Number to format.
+   * @param string $langcode
+   *   Language code.
+   *
+   * @return string
+   *   Formatted number.
+   */
+  public function formatNumber($number, $langcode) {
+    if (is_string($number) && !is_numeric($number)) {
+      return $this->t('NaN');
+    }
+    $format = $this->getSetting('format') ?? 'decimal';
+    if ($format === 'short' || $format === 'long') {
+      $precision = (int) $this->getSetting('precision') ?? 1;
+      return $this->formatNumberCompact($number, $langcode, $format, $precision);
+    }
+    return $this->formatNumberDecimal($number, $langcode);
+  }
+
+  /**
+   * Format a number with language aware compact decimal formatting.
+   *
+   * If the language is not supported or no pattern was found, the returned
+   * number will be formatted with the grouped thousands formatting.
+   *
+   * @param float|int $number
+   *   Number to format.
+   * @param string $langcode
+   *   Language code.
+   * @param string $type
+   *   Either 'short' or 'long' (default).
+   * @param int $precision
+   *   Precision for the rounding of the number once compacted.
+   *
+   * @return string
+   *   Formatted number.
+   *
+   * @see http://st.unicode.org/cldr-apps/v#/fr/Compact_Decimal_Formatting
+   */
+  public function formatNumberCompact($number, $langcode, $type = 'long', $precision = 2) {
+    if ($number < 1000) {
+      return $number;
+    }
+    elseif ($number >= 1e15) {
+      return $this->formatNumberDecimal($number, $langcode);
+    }
+
+    // Skip if the language is not handled.
+    if (empty($this->patterns[$langcode])) {
+      return $this->formatNumberDecimal($number, $langcode);
+    }
+
+    // Get the pattern for the language and type. Skip if undefined.
+    if (!isset($this->patterns[$langcode][$type])) {
+      return $this->formatNumberDecimal($number, $langcode);
+    }
+    $patterns = $this->patterns[$langcode][$type];
+
+    // We want something like 1.2 million not 1,200,000, so we "truncate" the
+    // number to a value between 0 and 1000 (not included).
+    $n = abs($number);
+    $p = floor(($n ? log($n) : 0) / log(1000));
+    $n = $n / pow(1000, $p);
+
+    // Retrieve the pattern key for the number (ex: 1000000). Skip if Undefined.
+    $key = (string) pow(1000, $p);
+    if (empty($patterns[$key])) {
+      return $this->formatNumberDecimal($number, $langcode);
+    }
+    $patterns = $patterns[$key];
+
+    // Get the language plural for the number and lookup for the corresponding
+    // pattern. Skip if undefined.
+    $plural = $this->getPluralFor($n, $langcode);
+    if (empty($patterns[$plural])) {
+      return $this->formatNumberDecimal($number, $langcode);
+    }
+
+    // The GHO print version doesn't seem to translate the truncated part of the
+    // number (ex: 1.2) for Arabic and use the English notation instead so we
+    // do the same here.
+    //
+    // @todo Confirm?
+    if ($langcode === 'ar') {
+      $number = $this->formatNumberDecimal(round($n, $precision), 'en');
+    }
+    else {
+      $number = $this->formatNumberDecimal(round($n, $precision), $langcode);
+    }
+
+    // Return the compact number.
+    return preg_replace('/0+/u', $number, $patterns[$plural]);
+  }
+
+  /**
+   * Format a number with grouped thousands.
+   *
+   * @param float|int $number
+   *   Number to format.
+   * @param string $langcode
+   *   Language code.
+   *
+   * @return string
+   *   Formatted number.
+   */
+  public function formatNumberDecimal($number, $langcode) {
+    if (class_exists('\NumberFormatter')) {
+      $formatter = new \NumberFormatter($langcode, \NumberFormatter::DECIMAL);
+      $formatted = $formatter->format($number);
+      if (intl_is_failure($formatter->getErrorCode())) {
+        return $number;
+      }
+      return $formatted;
+    }
+    return number_format($number);
+  }
+
+  /**
+   * Get the language plural corresponding to the given number.
+   *
+   * Note: this only implements the rules for Arabic, English, Spanish and
+   * French.
+   *
+   * @param float|int $number
+   *   Number to format, truncated to be within the 0-1000 range.
+   * @param string $langcode
+   *   Language code.
+   *
+   * @return string
+   *   Plural for the number. It can be "one", "two", "few", "many" or "other".
+   *
+   * @see http://cldr.unicode.org/index/cldr-spec/plural-rules
+   * @see http://unicode.org/reports/tr35/tr35-numbers.html#Language_Plural_Rules
+   * @see https://unicode-org.github.io/cldr-staging/charts/38/supplemental/language_plural_rules.html
+   */
+  public function getPluralFor($number, $langcode) {
+    /*
+     * n: absolute value of the source number.
+     * i: integer digits of n.
+     * v: number of visible fraction digits in n, with trailing zeros.
+     * w: number of visible fraction digits in n, without trailing zeros.
+     * f: visible fraction digits in n, with trailing zeros.
+     * t: visible fraction digits in n, without trailing zeros.
+     * c: compact decimal exponent value: exponent of the power of 10 used in
+     *    compact decimal formatting.
+     * e: currently, synonym for ‘c’. however, may be redefined in the future.
+     *
+     * Rules from:
+     * http://unicode.org/reports/tr35/tr35-numbers.html#Plural_Operand_Meanings
+     */
+
+    $n = abs($number);
+    $i = floor($n);
+
+    $c = floor(log10($n));
+
+    // To handle both scientific notation (1.23456e-3) and plain notation
+    // (0.00123456), we use sprintf() to print in a consistent manner the float
+    // value to extract the decimals.
+    //
+    // The number of decimals to print takes into account the precision of 14
+    // decimal digits for floats.
+    //
+    // @see https://www.php.net/manual/en/language.types.float.php
+    $p = $c < 0 ? 1 - $c : max(14 - $c, 0);
+    $f = rtrim(substr(strstr(sprintf('%.' . $p . 'f', $n), '.'), 1), '0');
+
+    // We already removed trailing zeros to avoid artifacts from the sprintf.
+    // This doesn't have any impact on the language plural rules we support.
+    $v = strlen($f);
+
+    /*
+     * Those variables are not used for the languages we support:
+     * - $e = $c;
+     * - $t = rtrim($f, '0');
+     * - $w = strlen($t);
+     */
+
+    // The rules here are based on the rules and compact decimal values for
+    // the languages, adapted to our use case where we provide a number between
+    // 0 and 1000.
+    switch ($langcode) {
+      // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/ar.html
+      case 'ar':
+        if ($n === 0) {
+          return 'zero';
+        }
+        elseif ($n === 1) {
+          return 'one';
+        }
+        elseif ($n === 2) {
+          return 'two';
+        }
+        elseif (($n % 100 >= 3) && ($n % 100 <= 10)) {
+          return 'few';
+        }
+        elseif (($n % 100 >= 11) && ($n % 100 <= 99)) {
+          return 'many';
+        }
+        return 'other';
+
+      // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/en.html
+      case 'en':
+        if ($i === 1 && $v === 0) {
+          return 'one';
+        }
+        return 'other';
+
+      // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/es.html
+      case 'es':
+        if ($n === 1) {
+          return 'one';
+        }
+        return 'other';
+
+      // @see https://unicode-org.github.io/cldr-staging/charts/38/verify/numbers/fr.html
+      //
+      // Note: the examples are not correct in the linked page above:
+      // "1.1 millions" should be "1.1 million" for example, because the rule is
+      // that any quantity below 2 are singular even for high numbers
+      // (mille, million etc.).
+      // Example from GHO 2019: "1,6 million de femmes enceintes".
+      case 'fr':
+        if ($i === 0 || $i === 1) {
+          return 'one';
+        }
+        return 'other';
+
+    }
+    return 'other';
+  }
+
+}

--- a/html/modules/custom/gho_figures/README.md
+++ b/html/modules/custom/gho_figures/README.md
@@ -1,0 +1,8 @@
+Global Humanitarian Overview - Figures Module
+=============================================
+
+This module provides a form (/admin/content/needs-and-requirements/import) to
+import a spreadsheet with the "needs and reuqirements" figures (also known as
+"top figures").
+
+This requires the "Needs and requirements" vocabulary.

--- a/html/modules/custom/gho_figures/composer.json
+++ b/html/modules/custom/gho_figures/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "unocha/gho_figures",
+    "description": "Global Humanitarian Overview Figures Import.",
+    "type": "drupal-module",
+    "authors": [
+        {
+            "name": "UNOCHA"
+        }
+    ],
+    "keywords": [
+        "Drupal",
+        "Spreadsheet",
+        "Excel"
+    ],
+    "require": {
+        "phpoffice/phpspreadsheet": "^1.14.1"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/html/modules/custom/gho_figures/gho_figures.info.yml
+++ b/html/modules/custom/gho_figures/gho_figures.info.yml
@@ -1,0 +1,5 @@
+type: module
+name: GHO Figures
+description: 'Figures import handling (ex: needs and requirements).'
+package: gho
+core_version_requirement: ^8.9 || ^9

--- a/html/modules/custom/gho_figures/gho_figures.links.action.yml
+++ b/html/modules/custom/gho_figures/gho_figures.links.action.yml
@@ -1,0 +1,5 @@
+gho_figures.import_needs_and_requirements:
+  title: 'Import needs and requirements figures'
+  route_name: gho_figures.import_needs_and_requirements
+  appears_on:
+    - view.needs_and_requirements.page_needs_and_requirements

--- a/html/modules/custom/gho_figures/gho_figures.module
+++ b/html/modules/custom/gho_figures/gho_figures.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Code for the GHO figures module.
+ */

--- a/html/modules/custom/gho_figures/gho_figures.permissions.yml
+++ b/html/modules/custom/gho_figures/gho_figures.permissions.yml
@@ -1,0 +1,3 @@
+import needs and requirements figures:
+  title: 'Import needs and requirements figures'
+  description: "Allow access to the form to upload a spreadsheet with new Needs and Requirements figures"

--- a/html/modules/custom/gho_figures/gho_figures.routing.yml
+++ b/html/modules/custom/gho_figures/gho_figures.routing.yml
@@ -1,0 +1,7 @@
+gho_figures.import_needs_and_requirements:
+  path: '/admin/content/needs_and_requirements/import'
+  defaults:
+    _form: '\Drupal\gho_figures\Form\GhoFiguresImportNeedsAndRequirementsFiguresForm'
+    _title: 'Import needs and requirements figures'
+  requirements:
+    _permission: 'import needs and requirements figures'

--- a/html/modules/custom/gho_figures/src/Form/GhoFiguresImportNeedsAndRequirementsFiguresForm.php
+++ b/html/modules/custom/gho_figures/src/Form/GhoFiguresImportNeedsAndRequirementsFiguresForm.php
@@ -1,0 +1,1184 @@
+<?php
+
+namespace Drupal\gho_figures\Form;
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\taxonomy\Entity\Term;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Worksheet\Row;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * GHO figures import form implementation.
+ */
+class GhoFiguresImportNeedsAndRequirementsFiguresForm extends FormBase {
+
+  /**
+   * Supported spreadsheet columns.
+   *
+   * Each column defintion can contain the following values:
+   * - legacy: indicates that the column itself is not used as is anymore
+   *   though it may still be used when processing other columns.
+   * - mandatory: indicates that the column must be present.
+   * - multiple: indicates that there may be multiple values for the column.
+   * - field: indicates the "needs and requirements" term's field to which the
+   *   column data will be added.
+   * - preprocess: array with a callback as first item and additional
+   *   arguments. The cell data will be preprocessed by this callback when
+   *   parsing a row. The callback will be passed the whole row's data by
+   *   reference and is expecting to modify the data (no return value).
+   *   The callback should return FALSE if the value was invalid.
+   * - process: array with a callback as first item and additional
+   *   arguments. The cell data will be processed by this callback when
+   *   added to the field.
+   * - table_display: array with a callback as first item and additional
+   *   arguments. The function will be called to generate the value to
+   *   display in the figures table in the confirmation step. The callback will
+   *   be passed the whole row's data.
+   *
+   * @var array
+   */
+  public static $columns = [
+    'name' => [
+      'mandatory' => TRUE,
+      'field' => 'name',
+      'label' => '',
+    ],
+    'people in need' => [
+      'mandatory' => TRUE,
+      'field' => 'field_people_in_need',
+      'label' => 'People in need',
+      'preprocess' => [
+        '\Drupal\gho_figures\Form\GhoFiguresImportNeedsAndRequirementsFiguresForm::preprocessNumber',
+      ],
+      'table_display' => [
+        '\Drupal\gho_figures\Form\GhoFiguresImportNeedsAndRequirementsFiguresForm::displayNumber',
+      ],
+    ],
+    'people targeted' => [
+      'field' => 'field_people_targeted',
+      'label' => 'People targeted',
+      'preprocess' => [
+        '\Drupal\gho_figures\Form\GhoFiguresImportNeedsAndRequirementsFiguresForm::preprocessNumber',
+      ],
+      'table_display' => [
+        '\Drupal\gho_figures\Form\GhoFiguresImportNeedsAndRequirementsFiguresForm::displayNumber',
+      ],
+    ],
+    'requirements (us$)' => [
+      'field' => 'field_requirements',
+      'label' => 'Requirements (US$)',
+      'preprocess' => [
+        '\Drupal\gho_figures\Form\GhoFiguresImportNeedsAndRequirementsFiguresForm::preprocessNumber',
+      ],
+      'table_display' => [
+        '\Drupal\gho_figures\Form\GhoFiguresImportNeedsAndRequirementsFiguresForm::displayNumber',
+      ],
+    ],
+  ];
+
+  /**
+   * Database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $database;
+
+  /**
+   * File system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * Configuration Factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * Entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Class constructor.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   Database connection.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   File system service.
+   * @param \Drupal\Core\Config\ConfigFactory $config_factory
+   *   Config factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger service.
+   */
+  public function __construct(Connection $database, FileSystemInterface $file_system, ConfigFactory $config_factory, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger) {
+    $this->database = $database;
+    $this->fileSystem = $file_system;
+    $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('database'),
+      $container->get('file_system'),
+      $container->get('config.factory'),
+      $container->get('entity_type.manager'),
+      $container->get('messenger')
+    );
+  }
+
+  /**
+   * Get a setting for the gho_figures module.
+   *
+   * @param string $setting
+   *   Setting name.
+   * @param mixed $default
+   *   Default value for the setting.
+   *
+   * @return mixed
+   *   Value for the setting.
+   */
+  public function getSetting($setting, $default = NULL) {
+    static $settings;
+    if (!isset($settings)) {
+      $settings = $this->configFactory->get('gho_figures.settings');
+    }
+    return $settings->get($setting) ?? $default;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'gho_figures_import_needs_and_requirements_figures_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['actions'] = [
+      '#type' => 'actions',
+      // Ensure it's at the bottom of the list.
+      '#weight' => 10,
+    ];
+
+    if ($form_state->has('step') && $form_state->get('step') == 2) {
+      return self::buildFormStepTwo($form, $form_state);
+    }
+    else {
+      return self::buildFormStepOne($form, $form_state);
+    }
+  }
+
+  /**
+   * Build the first step of the form with the file upload.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   Modified form.
+   */
+  public function buildFormStepOne(array $form, FormStateInterface $form_state) {
+    $form_state->set('step', 1);
+
+    $form['description'] = [
+      '#type' => 'item',
+      '#title' => $this->t('<h2>Step 1: File Upload</h2>'),
+    ];
+
+    $form['tips'] = [
+      '#type' => 'item',
+      '#markup' => $this->t('
+        <h3>Tips</h3>
+        <ul>
+          <li>Make sure the spreadsheet contains those 4 columns:
+            <ol>
+              <li>"Name" column (with overviews and appeals; assumed to be the first column)</li>
+              <li>People in need</li>
+              <li>People targeted</li>
+              <li>Requirements (US$)</li>
+            </ol>
+          </li>
+          <li>Make sure all the figures are non formatted numbers (ex: 1200000 not 1.2 million)</li>
+        </ul>
+      '),
+    ];
+
+    $form['file'] = [
+      '#type' => 'managed_file',
+      '#title' => $this->t('Spreadsheet file'),
+      '#description' => $this->t('Spreadsheet file with the figures. Accepted formats are: xls, xlsx, ods, csv.'),
+      '#required' => TRUE,
+      '#default_value' => $form_state->getValue('file'),
+      '#upload_location' => 'temporary://figures-import',
+      '#upload_validators' => [
+        'file_validate_extensions' => ['xls xlsx ods csv'],
+      ],
+    ];
+
+    // Proceed to step 2.
+    $form['actions']['next'] = [
+      '#type' => 'submit',
+      '#button_type' => 'primary',
+      '#value' => $this->t('Next'),
+      '#submit' => ['::submitFormStepOne'],
+      '#validate' => ['::validateFormStepOne'],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Validate the first step of the form.
+   *
+   * Here we also parse the spreadsheet file and extract the figures.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function validateFormStepOne(array &$form, FormStateInterface $form_state) {
+    $fids = $form_state->getValue('file');
+    if (!empty($fids)) {
+      // Load the file object and get its real path as that's what
+      // PHPSpreadsheet expects.
+      $file = $this->entityTypeManager->getStorage('file')->load(reset($fids));
+      $path = $this->fileSystem->realpath($file->getFileUri());
+
+      // Maximum number of rows that can be parsed to limit memory consumption.
+      // In our case, there will be probably be less than 100 rows.
+      $max_rows = $this->getSetting('max_rows', 9999);
+
+      // Extract the figures from the spreadsheet.
+      $figures = static::parseSpreadsheet($path, $max_rows);
+      if (empty($figures['figures']) && !empty($figures['errors'])) {
+        $form_state->setErrorByName('file', $this->t("Unable to extract figures from the spreadsheet: \n@errors.", [
+          '@errors' => static::formatList($figures['errors']),
+        ]));
+      }
+      else {
+        $form_state->set('figures', $figures);
+      }
+    }
+  }
+
+  /**
+   * Submit the first step of the form.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function submitFormStepOne(array &$form, FormStateInterface $form_state) {
+    $form_state
+      ->set('first_step_values', ['file' => $form_state->getValue('file')])
+      ->set('step', 2)
+      ->setRebuild(TRUE);
+  }
+
+  /**
+   * Build the second step of the form with the confirmation.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   Modified form.
+   */
+  public function buildFormStepTwo(array $form, FormStateInterface $form_state) {
+    $form_state->set('step', 2);
+
+    $form['description'] = [
+      '#type' => 'item',
+      '#title' => $this->t('<h2>Step 2: Confirmation</h2>'),
+    ];
+
+    // Display the table with the list of figures to import.
+    $figures = $form_state->get('figures');
+    if (!empty($figures['figures'])) {
+      // Maximum number of figures to show.
+      $count = count($figures['figures']);
+      $headers = static::getTableHeaders($figures['columns']);
+      $rows = static::getTableRows($headers, $figures['figures']);
+
+      $form['figure-list'] = [
+        '#type' => 'details',
+        '#title' => $this->formatPlural($count,
+          '@count figure to import',
+          '@count figures to import'
+        ),
+        'table' => [
+          '#type' => 'table',
+          '#header' => $headers,
+          '#rows' => $rows,
+        ],
+      ];
+    }
+
+    // Display the errors detected while parsing the spreadsheet.
+    if (!empty($figures['errors'])) {
+      $count = count($figures['errors']);
+
+      $form['error-list'] = [
+        '#type' => 'details',
+        '#title' => $this->formatPlural($count,
+          '@count parsing error',
+          '@count parsing errors'
+        ),
+        'list' => [
+          '#theme' => 'item_list',
+          '#list_type' => 'ul',
+          '#items' => $figures['errors'],
+        ],
+      ];
+    }
+
+    // Button to go back to the step 1.
+    $form['actions']['back'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Back'),
+      '#submit' => ['::cancelFormStepTwo'],
+      // Prevent validation errors as we are going back and the values from
+      // the step 2 should be ignored then.
+      '#limit_validation_errors' => [],
+    ];
+
+    // Submit the form, actually replacing the figures.
+    // We default to base form submit and validation callbacks.
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#button_type' => 'primary',
+      '#value' => $this->t('Import figures'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Get the figures table headers to display in the import confirmation step.
+   *
+   * @param array $columns
+   *   Array of Header columns with the names as keys.
+   *
+   * @return array
+   *   List of table headers.
+   */
+  public static function getTableHeaders(array $columns) {
+    $headers = [];
+
+    foreach (static::$columns as $name => $definition) {
+      if (isset($columns[$name])) {
+        $headers[$name] = $definition['label'];
+      }
+    }
+
+    return $headers;
+  }
+
+  /**
+   * Get the figures table rows to display in the import confirmation step.
+   *
+   * @param array $headers
+   *   List of header column names.
+   * @param array $figures
+   *   List of figures data extracted from the spreadsheet.
+   *
+   * @return array
+   *   Table rows. Each row contains cells for each column. Each cell can be
+   *   either a string or a render array.
+   */
+  public static function getTableRows(array $headers, array $figures) {
+    $rows = [];
+    foreach ($figures as $data) {
+      $row = [];
+      foreach ($headers as $name => $label) {
+        if (isset(static::$columns[$name]['table_display'])) {
+          $row[$name] = static::call(static::$columns[$name]['table_display'] + [
+            'name' => $name,
+          ], $data);
+        }
+        else {
+          $row[$name] = $data[$name] ?? '';
+        }
+      }
+      $rows[] = $row;
+    }
+    return $rows;
+  }
+
+  /**
+   * Return to the first step.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function cancelFormStepTwo(array &$form, FormStateInterface $form_state) {
+    $form_state
+      ->setValues($form_state->get('first_step_values'))
+      ->set('step', 1)
+      ->setRebuild(TRUE);
+  }
+
+  /**
+   * Validate the form (after step 2).
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Nothing to validate.
+  }
+
+  /**
+   * Submit the form (after step 2).
+   *
+   * Generate the batch to update the "needs and requirements" figures.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $batch_size = $this->getSetting('batch_size', 50);
+
+    // We will (optionally) delete the old figures and create the new ones
+    // in batches as that takes time.
+    $figures = $form_state->get('figures');
+    if (!empty($figures['figures'])) {
+      $operations = [];
+
+      // We log the parsing errors (if any) during the batch process because
+      // otherwise it slows down too much the parsing. Also it makes more sense
+      // to log them when actually proceeding with the import.
+      $operations[] = [
+        __CLASS__ . '::logParsingInfo',
+        [$figures['path'], $figures['errors']],
+      ];
+
+      // Extract the name of the figures to update/create.
+      $names = array_map(function ($figure) {
+        return $figure['name'];
+      }, $figures['figures']);
+
+      // Create batch steps to delete figure terms not present in the list.
+      $records = $this->entityTypeManager->getStorage('taxonomy_term')->getQuery()
+        ->condition('vid', 'needs_and_requirements')
+        ->condition('name', $names, 'NOT IN')
+        ->accessCheck(FALSE)
+        ->execute();
+
+      if (!empty($records)) {
+        foreach (array_chunk($records, $batch_size) as $ids) {
+          $operations[] = [__CLASS__ . '::deleteFigureTerms', [$ids]];
+        }
+      }
+
+      // Create batch steps to create the new figure terms.
+      foreach (array_chunk($figures['figures'], $batch_size) as $data) {
+        $operations[] = [__CLASS__ . '::createFigureTerms', [$data]];
+      }
+
+      $batch = [
+        'title' => $this->t('Importing figures...'),
+        'operations' => $operations,
+        'finished' => __CLASS__ . '::batchFinished',
+      ];
+      batch_set($batch);
+    }
+    else {
+      $this->messenger->addWarning($this->t('No figures to import. Existing figures will not be updated.'));
+    }
+  }
+
+  /**
+   * Log the parsing errors.
+   *
+   * @param string $path
+   *   The path of the spreadsheet.
+   * @param array $errors
+   *   The parsing errors.
+   * @param array $context
+   *   The batch context.
+   */
+  public static function logParsingInfo($path, array $errors, array &$context) {
+    // Log the filename to help make sense of the parsing errors.
+    static::log(new FormattableMarkup('Parsed spreadsheet: @path', [
+      '@path' => $path,
+    ]), 'info');
+
+    // We log the errors as notices because they don't impact the whole site.
+    foreach ($errors as $error) {
+      static::log($error, 'notice');
+    }
+
+    // Set a message for the current batch and update the progress status.
+    $count = count($errors);
+    $context['message'] = \Drupal::translation()->formatPlural($count,
+      'Logged @count parsing error.',
+      'Logged @count parsing errors.'
+    );
+    $context['results']['logged'][] = $count;
+  }
+
+  /**
+   * Delete the "needs and requirements" figure terms for the given ids.
+   *
+   * Note: we don't actually delete the terms but wipe out their data and
+   * unpublish them so that we can preserve any references to them in article
+   * nodes for example, in case they are updated later on.
+   *
+   * @param array $ids
+   *   Term ids.
+   * @param array $context
+   *   The batch context.
+   */
+  public static function deleteFigureTerms(array $ids, array &$context) {
+    $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+
+    // Unpublish the terms that are not used.
+    $terms = $storage->loadMultiple($ids);
+    foreach ($terms as $term) {
+      $term->published = FALSE;
+      // Wipe out the values of the figures for the term.
+      foreach (static::$columns as $definition) {
+        if (isset($definition['field'])) {
+          $term->set($definition['field'], NULL);
+        }
+      }
+      $term->save();
+    }
+
+    // Set a message for the current batch and update the progress status.
+    $count = count($ids);
+    $context['message'] = \Drupal::translation()->formatPlural($count,
+      'Deleted @count old figure.',
+      'Deleted @count old figures.'
+    );
+    $context['results']['deleted'][] = $count;
+  }
+
+  /**
+   * Create new "needs and requirements" figure terms.
+   *
+   * Note: if a term already exists, we simply update it.
+   *
+   * @param array $figures
+   *   Figure data.
+   * @param array $context
+   *   The batch context.
+   */
+  public static function createFigureTerms(array $figures, array &$context) {
+    $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+
+    // Create a new term for each figure.
+    foreach ($figures as $figure) {
+      // Check if a term with the same name already exists and re-use it.
+      $terms = $storage->loadByProperties([
+        'vid' => 'needs_and_requirements',
+        'name' => $figure['name'],
+      ]);
+
+      if (!empty($terms)) {
+        $term = reset($terms);
+      }
+      else {
+        $term = $storage->create(['vid' => 'needs_and_requirements']);
+      }
+
+      // Update the term fields.
+      static::updateFigureTerm($term, $figure);
+      $term->published = TRUE;
+      $term->save();
+    }
+
+    // Set a message for the current batch and update the progress status.
+    $count = count($figures);
+    $context['message'] = \Drupal::translation()->formatPlural($count,
+      'Created/updated @count new figure.',
+      'Created/updated @count new figures.'
+    );
+    $context['results']['created'][] = $count;
+  }
+
+  /**
+   * Update a "needs and requirements" figure term's fields with new data.
+   *
+   * @param \Drupal\taxonomy\Entity\Term $term
+   *   Node to update.
+   * @param array $data
+   *   New figure data.
+   *
+   * @todo review if we should get the node fields via ::getFields() and
+   * reset all the fields for which there is no corresponding data.
+   */
+  public static function updateFigureTerm(Term $term, array $data) {
+    foreach (static::$columns as $name => $definition) {
+      if (!isset($definition['field'])) {
+        continue;
+      }
+      $field = $definition['field'];
+      $value = NULL;
+      if (isset($data[$name])) {
+        $value = $data[$name];
+
+        if (isset($definition['process'])) {
+          $value = static::call($definition['process'] + ['name' => $name], $value);
+        }
+      }
+      $term->set($field, $value);
+    }
+  }
+
+  /**
+   * Display message after the batch import is finished.
+   *
+   * @param bool $success
+   *   Whether the batch process succeeeded or not.
+   * @param array $results
+   *   Batch results.
+   * @param array $operations
+   *   List of batch operations.
+   */
+  public static function batchFinished($success, array $results, array $operations) {
+    if ($success) {
+      if (!empty($results['deleted'])) {
+        \Drupal::messenger()->addStatus(t('Deleted %deleted old figures.', [
+          '%deleted' => array_sum($results['deleted']),
+        ]));
+      }
+      if (!empty($results['created'])) {
+        \Drupal::messenger()->addStatus(t('Created/updated %created figures.', [
+          '%created' => array_sum($results['created']),
+        ]));
+      }
+    }
+    else {
+      // @todo Show a more useful error message?
+      \Drupal::messenger()->addError(t('No figures to import. Old figures were not deleted.'));
+    }
+  }
+
+  /**
+   * Get a taxonomy term ID. Create a new term if necessary.
+   *
+   * @param string $vocabulary
+   *   Taxonomy vocabulary.
+   * @param string|array $name
+   *   Taxonomy term name or array of names.
+   *
+   * @return int|null
+   *   Id of the first term, newly created if doesn't already exists.
+   */
+  public static function getTermId($vocabulary, $name) {
+    $multiple = is_array($name);
+
+    $names = array_filter(array_map('trim', $multiple ? $name : [$name]));
+
+    if (empty($names)) {
+      return NULL;
+    }
+
+    $results = [];
+    foreach ($names as $name) {
+      $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+
+      // Sanitize and truncate the term if necessary.
+      $words = preg_split('/' . Unicode::PREG_CLASS_WORD_BOUNDARY . '/u', $name, -1, PREG_SPLIT_NO_EMPTY);
+      if (count($words) > 10) {
+        $name = implode(' ', array_slice($words, 0, 10)) . ' ...';
+      }
+
+      // Get any existing taxonomy term matching the given term name.
+      $terms = $term_storage->loadByProperties([
+        'vid' => $vocabulary,
+        'name' => $name,
+      ]);
+
+      // Get the first existing term or create one.
+      if (!empty($terms)) {
+        $term = reset($terms);
+      }
+      else {
+        $term = $term_storage->create([
+          'vid' => $vocabulary,
+          'name' => $name,
+        ]);
+        $term->save();
+      }
+      $results[] = $term->id();
+    }
+
+    return $multiple ? $results : reset($results);
+  }
+
+  /**
+   * Extract figures from a spreadsheet.
+   *
+   * @param string $path
+   *   File path.
+   * @param int $max_rows
+   *   Maximum number rows to parse.
+   *
+   * @return array
+   *   Associative array with the spreadsheet file path, the header columns,
+   *   figure list and potential parsing errors.
+   */
+  public static function parseSpreadsheet($path, $max_rows) {
+    $columns = [];
+    $figures = [];
+    $errors = [];
+
+    // We wrap this code in a try...catch because PHPSpreadsheet can throw
+    // various exceptions when parsing a spreadsheet.
+    try {
+      // Get the worksheet to work with (pun intended).
+      $sheet = static::getWorksheet($path);
+
+      // Get the row to which will stop the parsing.
+      $max_rows = min($sheet->getHighestDataRow(), $max_rows);
+
+      // Parse the sheet, extracting figure data.
+      $header_row_found = FALSE;
+      foreach ($sheet->getRowIterator(1, $max_rows) as $row) {
+        // Parse the row to see if it's the header one.
+        if ($header_row_found === FALSE) {
+          $data = static::parseHeaderRow($sheet, $row);
+          // There are errors if the header row was found but some mandatory
+          // columns are missing. In that case we abort the parsing.
+          if (!empty($data['errors'])) {
+            $errors = array_merge($errors, $data['errors']);
+            break;
+          }
+          // Otherwise if the header row was found, we store the columns and
+          // make sure we can start parsing the data. If not, we continue
+          // looking for it.
+          elseif (!empty($data['columns'])) {
+            $columns = $data['columns'];
+            $header_row_found = TRUE;
+          }
+        }
+        // Parse a figure data row.
+        else {
+          $data = static::parseDataRow($columns, $sheet, $row);
+          if (!empty($data['data'])) {
+            // Log the errors only for "useful" rows with some data.
+            if (!empty($data['errors'])) {
+              $errors = array_merge($errors, $data['errors']);
+            }
+            // If there is an email, merge the data with the figure entry with
+            // the same email address if any, otherwise create a new entry if
+            // the data is "valid", meaning, it has all the mandatory fields.
+            if (!empty($data['data']['name'])) {
+              $figures[$data['data']['name']] = $data['data'];
+            }
+          }
+        }
+      }
+    }
+    catch (\Exception $exception) {
+      $errors[] = $exception->getMessage();
+    }
+
+    return [
+      'path' => $path,
+      'columns' => $columns,
+      'figures' => $figures,
+      'errors' => $errors,
+    ];
+  }
+
+  /**
+   * Load a spreadsheet and return its first worksheet.
+   *
+   * @param string $path
+   *   File path.
+   *
+   * @return \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet
+   *   First worksheet.
+   */
+  public static function getWorksheet($path) {
+    if (!file_exists($path)) {
+      throw new \Exception("The spreadsheet file doesn't exist.");
+    }
+
+    // Get the spreadsheet type.
+    $filetype = IOFactory::identify($path);
+
+    // Create the spreadsheet reader.
+    $reader = IOFactory::createReader($filetype);
+
+    // Start reading the file.
+    $spreadsheet = $reader->load($path);
+
+    // We only deal with the first sheet.
+    return $spreadsheet->getActiveSheet();
+  }
+
+  /**
+   * Parse a row, attempting to determine if its the header row.
+   *
+   * @param \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet
+   *   Spreadsheet worksheet.
+   * @param \PhpOffice\PhpSpreadsheet\Worksheet\Row $row
+   *   Spreadsheet row.
+   *
+   * @return array
+   *   Empty array if the row is not the header row, otherwise, return an
+   *   associative array with the found columns which is an associative array
+   *   with the column name (header) as value and the column letter as value.
+   *   If the row is the header one but some mandatory columns are missing, the
+   *   returnning array will have an `errors` key with the list of errors.
+   */
+  public static function parseHeaderRow(Worksheet $sheet, Row $row) {
+    $columns = [];
+    foreach ($row->getCellIterator() as $index => $cell) {
+      $value = mb_strtolower(static::getCellValue($sheet, $cell->getCoordinate()));
+      // Fix malformed column names...
+      $value = trim(preg_replace('/\s+/u', ' ', $value));
+      if (isset($value, static::$columns[$value]) && !isset($columns[$value])) {
+        $columns[$value] = $cell->getColumn();
+      }
+      // If the first column doesn't have a name we assume it is the "name"
+      // column with the overviews and appeals.
+      elseif ($index === 'A') {
+        $columns['name'] = $cell->getColumn();
+      }
+    }
+
+    if (count($columns) < 2) {
+      return [];
+    }
+
+    // Validate mandatory columns.
+    $errors = [];
+    foreach (static::$columns as $name => $definition) {
+      if (!static::checkMandatoryField($name, $definition, $columns)) {
+        // We use TranslatableMarkup so that the error can be displayed
+        // translated in the confirmation step.
+        $errors[] = new TranslatableMarkup('Missing @column column.', [
+          '@column' => $name,
+        ]);
+      }
+    }
+
+    return [
+      'columns' => $columns,
+      'errors' => $errors,
+    ];
+  }
+
+  /**
+   * Parse a row with figure data.
+   *
+   * @todo Check if we need to use getCalculatedValue() instead of getValue().
+   *
+   * @param array $columns
+   *   Associative array of header columns with their associated column index.
+   * @param \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet
+   *   Spreadsheet worksheet.
+   * @param \PhpOffice\PhpSpreadsheet\Worksheet\Row $row
+   *   Spreadsheet row.
+   *
+   * @return array
+   *   Associative array with the following keys:
+   *   - data: associative array mapping the column names to their values,
+   *   - errors: array with a list of parsing errors,
+   *   - valid: a flag to indicate that the data contains all the mandatory
+   *   fields.
+   */
+  public static function parseDataRow(array $columns, Worksheet $sheet, Row $row) {
+    $index = $row->getRowIndex();
+    $data = [];
+    $errors = [];
+    $valid = TRUE;
+
+    // Get the data from the row foreach column with a recognized header.
+    foreach ($columns as $name => $column) {
+      $data[$name] = static::getCellValue($sheet, $column . $index);
+    }
+
+    // Skip if there no valid cell beside the name one as it's probably
+    // not a data row.
+    $skip = count(array_filter($data, function ($value, $name) {
+      return $name !== 'name' && $value !== '';
+    }, ARRAY_FILTER_USE_BOTH)) === 0;
+
+    if ($skip) {
+      return [];
+    }
+
+    // Process the row's data.
+    foreach (static::$columns as $name => $definition) {
+      if (isset($definition['preprocess'])) {
+        if (!static::call($definition['preprocess'] + ['name' => $name], $data)) {
+          $errors[$name] = new TranslatableMarkup('Invalid @column on row @row.', [
+            '@column' => $name,
+            '@row' => $index,
+          ]);
+        }
+      }
+    }
+
+    // Check mandatory fields. This is not done in the loop above because
+    // the data may change during preprocessing.
+    foreach (static::$columns as $name => $definition) {
+      if (!static::checkMandatoryField($name, $definition, $data)) {
+        // No need to add different error messages for the same field, for
+        // example if the field data was found invalid during preprocessing.
+        if (!isset($errors[$name])) {
+          $errors[$name] = new TranslatableMarkup('Missing @column on row @row.', [
+            '@column' => $name,
+            '@row' => $index,
+          ]);
+        }
+        $valid = FALSE;
+      }
+    }
+
+    return [
+      'data' => $data,
+      'errors' => array_values($errors),
+      'valid' => $valid,
+    ];
+  }
+
+  /**
+   * Get a cell value.
+   *
+   * This extracts the value of a cell. If the cell is merged with other cells
+   * we extract the combine value for the whole merge range.
+   *
+   * @param \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet
+   *   Spreadsheet worksheet.
+   * @param string $reference
+   *   Cell reference (ex: A1).
+   *
+   * @return string
+   *   Extracted value, defaulting to an empty string.
+   */
+  public static function getCellValue(Worksheet $sheet, $reference) {
+    static $references;
+    static $values;
+
+    if (!isset($references, $values)) {
+      list($references, $values) = static::extractMergedCells($sheet);
+    }
+
+    if (isset($references[$reference])) {
+      return $values[$references[$reference]];
+    }
+    elseif ($sheet->getCellCollection()->has($reference)) {
+      return trim($sheet->getCellCollection()->get($reference)->getValue());
+    }
+    return '';
+  }
+
+  /**
+   * Extract the values for the merged cells.
+   *
+   * We store the merged cells references and the merge range values so that
+   * we don't have to parse the merge ranges every time we try to get a cell
+   * value. This speeds tremendously the spreadsheet parsing at the cost of
+   * increased memory usage.
+   *
+   * @param \PhpOffice\PhpSpreadsheet\Worksheet\Worksheet $sheet
+   *   Worksheet from which to extract the merged cells data.
+   *
+   * @return array
+   *   Array containing 2 elements: an associative array  of the references of
+   *   the cells included in merge ranges mapped to to the range reference, and
+   *   an associative array mapping range references to their values.
+   */
+  public static function extractMergedCells(Worksheet $sheet) {
+    $references = [];
+    $values = [];
+
+    foreach ($sheet->getMergeCells() as $range) {
+      // Extract all the merged cell references and store their mapping to
+      // the merge range. We don't copy directly the merge range value to
+      // reduce memory usage.
+      foreach (Coordinate::extractAllCellReferencesInRange($range) as $index => $reference) {
+        // The first cell of the range is supposed to contain the value of the
+        // range.
+        // @see \PhpOffice\PhpSpreadsheet\Cell\Cell::isMergeRangeValueCell()
+        if ($index === 0) {
+          if ($sheet->getCellCollection()->has($reference)) {
+            $values[$range] = trim($sheet->getCellCollection()->get($reference)->getValue());
+          }
+          else {
+            $values[$range] = '';
+          }
+        }
+        $references[$reference] = $range;
+      }
+    }
+    return [$references, $values];
+  }
+
+  /**
+   * Preprocess the duty station country field.
+   *
+   * This extracts the countries from the `country` field or from the
+   * `duty station country` field if the former is empty.
+   *
+   * @param string $name
+   *   Field name.
+   * @param array $data
+   *   Row data.
+   *
+   * @return bool
+   *   FALSE if the data was invalid, TRUE otherwise.
+   */
+  public static function preprocessNumber($name, array &$data) {
+    if (isset($data[$name])) {
+      $options = ['options' => ['min_range' => 0]];
+      $value = filter_var($data[$name], FILTER_VALIDATE_INT, $options);
+      // Remove the value if it's not a positive integer so that the row
+      // will be removed and an error displayed.
+      if ($value === FALSE) {
+        unset($data[$name]);
+        return FALSE;
+      }
+      else {
+        $data[$name] = $value;
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Get a render array/string to display a formatted number (ex: 1.2 million).
+   *
+   * @param string $name
+   *   Field name.
+   * @param array $data
+   *   Figure data.
+   *
+   * @return array|string
+   *   Render array or empty string.
+   */
+  public static function displayNumber($name, array $data) {
+    if (!isset($data[$name])) {
+      return '';
+    }
+    // @todo use the same formatter as the one used to render the figures in
+    // the frontend (ex: 1.2 million).
+    return number_format($data[$name]);
+  }
+
+  /**
+   * Helper method to display a list of items as a HTML list.
+   *
+   * @param array $items
+   *   List of strings.
+   *
+   * @return \Drupal\Component\Render\FormattableMarkup
+   *   FormattableMarkup object containing the HTML list that can be passed
+   *   as placeholder replacement to `t()`.
+   */
+  public static function formatList(array $items) {
+    $html = '<ul><li>' . implode('</li><li>', $items) . '</li></ul>';
+    return new FormattableMarkup($html, []);
+  }
+
+  /**
+   * Check of the given data contains the mandatory field data.
+   *
+   * @param string $name
+   *   Column name.
+   * @param array $definition
+   *   Column definition.
+   * @param array $data
+   *   Field data.
+   *
+   * @return bool
+   *   Whether the field is present or not.
+   */
+  public static function checkMandatoryField($name, array $definition, array $data) {
+    return empty($definition['mandatory']) || isset($data[$name]);
+  }
+
+  /**
+   * Call a function with the given arguments and data.
+   *
+   * @param array $arguments
+   *   Array with the callable function/method as first element and with the
+   *   rest as parameters to pass to the callable.
+   * @param mixed $data
+   *   Additional data to pass to the callable. It is passed by reference and
+   *   may be modified by the callable.
+   *
+   * @return mixed
+   *   The result of the call.
+   */
+  public static function call(array $arguments, &$data) {
+    $callable = array_shift($arguments);
+    $arguments[] = &$data;
+    return call_user_func_array($callable, $arguments);
+  }
+
+  /**
+   * Log a message.
+   *
+   * @param mixed $message
+   *   String-ish value. If the message is an instance of
+   *   \Drupal\Core\StringTranslation\TranslatableMarkup then we build a non
+   *   translated message as the logs are for internal information and it
+   *   doesn't make sense to have them in the display language of the current
+   *   user.
+   * @param string $level
+   *   Log level.
+   */
+  public static function log($message, $level = 'info') {
+    if ($message instanceof TranslatableMarkup) {
+      $message = new FormattableMarkup($message->getUntranslatedString(), $message->getArguments());
+    }
+    \Drupal::logger('gho-figures-import')->log($level, $message);
+  }
+
+}

--- a/html/modules/custom/gho_figures/src/config/install/gho_figures.settings.yml
+++ b/html/modules/custom/gho_figures/src/config/install/gho_figures.settings.yml
@@ -1,0 +1,4 @@
+# Maximum number of rows to parse in the spreadsheet.
+max_rows: 9999
+# Number of figures to delete/create per batch.
+batch_size: 50

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -54,6 +54,11 @@ gho-separator:
     theme:
       components/gho-separator/gho-separator.css: {}
 
+gho-needs-and-requirements:
+  css:
+    theme:
+      components/gho-needs-and-requirements/gho-needs-and-requirements.css: {}
+
 gho-bleed:
   header: true
   js:

--- a/html/themes/custom/common_design_subtheme/components/gho-needs-and-requirements/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-needs-and-requirements/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Needs and requirements Component
+===============================================================
+
+Styling of the "needs and requirements" figures (also known as "top figures").

--- a/html/themes/custom/common_design_subtheme/components/gho-needs-and-requirements/gho-needs-and-requirements.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-needs-and-requirements/gho-needs-and-requirements.css
@@ -1,0 +1,45 @@
+.gho-needs-and-requirements {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+.gho-needs-and-requirements-figure {
+  padding: 1em 0;
+  border-style: solid;
+  border-color: #ccc;
+  border-width: 1px 0 0 0;
+}
+.gho-needs-and-requirements-figure__label {
+  font-weight: bold;
+}
+.gho-needs-and-requirements-figure__label small {
+  font-size: inherit;
+  font-weight: normal;
+}
+.gho-needs-and-requirements-figure__value {
+  font-weight: bold;
+  font-size: 2.25rem;
+  color: #5391cb;
+}
+
+@media (min-width: 768px) {
+  .gho-needs-and-requirements {
+    display: flex;
+    justify-content: space-between;
+  }
+  .gho-needs-and-requirements-figure {
+    display: inline-block;
+    flex: 1 0 33.33%;
+    border-width: 0 0 0 1px;
+    padding: 0 1.5em;
+  }
+  [dir="ltr"] .gho-needs-and-requirements-figure:first-child {
+    border-width: 0;
+    padding-left: 0;
+  }
+  [dir="rtl"] .gho-needs-and-requirements-figure:first-child {
+    padding-right: 0;
+  }
+  [dir="rtl"] .gho-needs-and-requirements-figure:last-child {
+    border-width: 0;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--taxonomy-term--needs-and-requirements.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--taxonomy-term--needs-and-requirements.html.twig
@@ -1,0 +1,58 @@
+{#
+/**
+ * @file
+ * Theme override for a "needs and requirements" field.
+ *
+ * Note: the label for the requirements is composed of 2 parts: label + unit. We
+ * handle the translation here as it's simple enough to not require a preprocess
+ * hook for that.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% spaceless %}
+<div class="gho-needs-and-requirements-figure">
+  <div class="gho-needs-and-requirements-figure__label">
+  {% if field_name == 'field_requirements' %}
+    {% trans %}Requirements <small>(US$)</small>{% endtrans %}
+  {% else %}
+    {{ label }}
+  {% endif %}
+  </div>
+  {% for item in items %}
+  <div class="gho-needs-and-requirements-figure__value">{{ item.content }}</div>
+  {% endfor %}
+</div>
+{% endspaceless %}
+

--- a/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--needs-and-requirements.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--needs-and-requirements.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override to display a "needs and requirements" taxonomy term.
+ *
+ * Available variables:
+ * - url: URL of the current term.
+ * - name: (optional) Name of the current term.
+ * - content: Items for the content of the term (fields and description).
+ *   Use 'content' to print them all, or print a subset such as
+ *   'content.description'. Use the following code to exclude the
+ *   printing of a given child element:
+ *   @code
+ *   {{ content|without('description') }}
+ *   @endcode
+ * - attributes: HTML attributes for the wrapper.
+ * - page: Flag for the full page state.
+ * - term: The taxonomy term entity, including:
+ *   - id: The ID of the taxonomy term.
+ *   - bundle: Machine name of the current vocabulary.
+ * - view_mode: View mode, e.g. 'full', 'teaser', etc.
+ *
+ * @see template_preprocess_taxonomy_term()
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-needs-and-requirements') }}
+{%
+  set classes = [
+    'taxonomy-term',
+    'vocabulary-' ~ term.bundle|clean_class,
+    'gho-needs-and-requirements',
+  ]
+%}
+<div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
+  {{ content }}
+</div>


### PR DESCRIPTION
Ticket: GHO-10

This adds the needs and requirements figures (top figures).

This creates a new vocabulary with terms matching the overviews and appeals as defined in the column 1 of the "Needs and requirements" spreadsheet. Each term has 3 fields for "people in need", "people targeted" and "requirements (US$)".

A form (/admin/content/needs-and-requirements/import) is provided to import the figures from the spreadsheet (`gho_figures` module).

Adding the figures to an article can be done by adding a "Needs and requirements" paragraph and selecting the appropriate "needs and requirements" term.

This makes the mapping and the styling fairly easy.

This PR also adds a Number formatter in the `gho_fields` module that can handle language aware compact number formatting: `1200000 => 1.2 million`. This follows the rules from the [Unicode Common Locale Data Repository](http://cldr.unicode.org/index/cldr-spec/plural-rules) to ensure the proper translation of the numbers with some GHO specific sauce.

The styling is fairly light:

<img width="1070" alt="Screen Shot 2020-10-29 at 18 57 37" src="https://user-images.githubusercontent.com/696348/97553326-a550b800-1a18-11eb-8da5-293ba7ccb0df.png">

<img width="806" alt="Screen Shot 2020-10-29 at 18 23 32" src="https://user-images.githubusercontent.com/696348/97553346-ab469900-1a18-11eb-9983-78d27560f6a4.png">

<img width="372" alt="Screen Shot 2020-10-29 at 18 58 32" src="https://user-images.githubusercontent.com/696348/97553486-d630ed00-1a18-11eb-9180-21ae43611dba.png">

<img width="528" alt="Screen Shot 2020-10-29 at 18 58 58" src="https://user-images.githubusercontent.com/696348/97553509-daf5a100-1a18-11eb-8407-944741d41c38.png">

## Testing

`composer update`, `drush cim` and `drush cr`.

Sample spreadsheet: 
[GHO2021_NeedsRequirements_2021-test1.xlsx](https://github.com/UN-OCHA/gho-site/files/5457519/GHO2021_NeedsRequirements_2021-test1.xlsx)

