### PR TITLE
[GHO-47] Sub-articles - Attempt 2

### DIFF
--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_related_articles
+    - field.field.node.article.field_section
     - field.field.node.article.field_summary
     - field.field.node.article.field_thumbnail_image
     - node.type.article
@@ -25,14 +26,14 @@ bundle: article
 mode: default
 content:
   field_appeals:
-    weight: 3
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_author:
     type: inline_entity_form_complex
-    weight: 4
+    weight: 3
     settings:
       form_mode: default
       override_labels: true
@@ -48,7 +49,7 @@ content:
     third_party_settings: {  }
     region: content
   field_further_reading:
-    weight: 11
+    weight: 10
     settings:
       placeholder_url: 'https://example.com'
       placeholder_title: 'Example URL Title'
@@ -57,13 +58,13 @@ content:
     region: content
   field_hero_image:
     type: media_library_widget
-    weight: 5
+    weight: 4
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    weight: 8
+    weight: 7
     settings:
       preview_view_mode: default
       nesting_depth: 4
@@ -72,7 +73,7 @@ content:
     type: layout_paragraphs
     region: content
   field_related_articles:
-    weight: 12
+    weight: 11
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -81,8 +82,14 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_section:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
   field_summary:
-    weight: 7
+    weight: 6
     settings:
       rows: 5
       placeholder: ''
@@ -91,21 +98,14 @@ content:
     region: content
   field_thumbnail_image:
     type: media_library_widget
-    weight: 6
+    weight: 5
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
-  langcode:
-    type: language_select
-    weight: 0
-    region: content
-    settings:
-      include_locked: true
-    third_party_settings: {  }
   path:
     type: path
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -113,25 +113,22 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 9
     region: content
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 2
+    weight: 1
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  translation:
-    weight: 1
-    region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
   created: true
+  langcode: true
   promote: true
   sticky: true
+  translation: true
   uid: true
   url_redirects: true

--- a/config/core.entity_form_display.paragraph.sub_article.default.yml
+++ b/config/core.entity_form_display.paragraph.sub_article.default.yml
@@ -1,0 +1,25 @@
+uuid: c8fafe85-d9aa-4390-b196-7bf72dcd15a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.sub_article.field_article
+    - paragraphs.paragraphs_type.sub_article
+id: paragraph.sub_article.default
+targetEntityType: paragraph
+bundle: sub_article
+mode: default
+content:
+  field_article:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_form_display.taxonomy_term.section.default.yml
+++ b/config/core.entity_form_display.taxonomy_term.section.default.yml
@@ -1,0 +1,39 @@
+uuid: e0bf36b5-bdc9-41eb-83b2-ec667464c4ab
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.section
+  module:
+    - text
+id: taxonomy_term.section.default
+targetEntityType: taxonomy_term
+bundle: section
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 2
+    region: content
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  path: true

--- a/config/core.entity_view_display.media.image.hero_image.yml
+++ b/config/core.entity_view_display.media.image.hero_image.yml
@@ -20,14 +20,6 @@ targetEntityType: media
 bundle: image
 mode: hero_image
 content:
-  field_credits:
-    type: string
-    weight: 1
-    region: content
-    label: hidden
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
   field_media_image:
     label: hidden
     weight: 0
@@ -39,6 +31,7 @@ content:
     region: content
 hidden:
   created: true
+  field_credits: true
   langcode: true
   name: true
   thumbnail: true

--- a/config/core.entity_view_display.node.article.default.yml
+++ b/config/core.entity_view_display.node.article.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_related_articles
+    - field.field.node.article.field_section
     - field.field.node.article.field_summary
     - field.field.node.article.field_thumbnail_image
     - node.type.article
@@ -22,7 +23,7 @@ bundle: article
 mode: default
 content:
   field_appeals:
-    weight: 1
+    weight: 2
     label: hidden
     settings:
       view_mode: default
@@ -32,7 +33,7 @@ content:
     region: content
   field_author:
     type: entity_reference_entity_view
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       view_mode: default
@@ -40,15 +41,15 @@ content:
     third_party_settings: {  }
     region: content
   field_further_reading:
-    weight: 5
-    label: hidden
+    weight: 6
+    label: visually_hidden
     settings: {  }
     third_party_settings: {  }
     type: gho_further_reading_link
     region: content
   field_hero_image:
     type: entity_reference_entity_view
-    weight: 2
+    weight: 3
     label: hidden
     settings:
       view_mode: hero_image
@@ -56,7 +57,7 @@ content:
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    weight: 4
+    weight: 5
     label: hidden
     settings:
       view_mode: default
@@ -65,13 +66,21 @@ content:
     type: layout_paragraphs
     region: content
   field_related_articles:
-    weight: 6
-    label: hidden
+    weight: 7
+    label: above
     settings:
       view_mode: related_article
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view
+    region: content
+  field_section:
+    weight: 1
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   links:
     weight: 0

--- a/config/core.entity_view_display.node.article.related_article.yml
+++ b/config/core.entity_view_display.node.article.related_article.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_related_articles
+    - field.field.node.article.field_section
     - field.field.node.article.field_summary
     - field.field.node.article.field_thumbnail_image
     - node.type.article
@@ -49,5 +50,6 @@ hidden:
   field_hero_image: true
   field_paragraphs: true
   field_related_articles: true
+  field_section: true
   langcode: true
   links: true

--- a/config/core.entity_view_display.node.article.sub_article.yml
+++ b/config/core.entity_view_display.node.article.sub_article.yml
@@ -1,9 +1,9 @@
-uuid: 5c24d6df-6ea9-475e-8136-fa6a941b5dd6
+uuid: ce31b97a-5150-4f1d-8d50-76fd0ddf134c
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
+    - core.entity_view_mode.node.sub_article
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_further_reading
@@ -15,36 +15,59 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
-    - text
+    - layout_builder
+    - layout_paragraphs
     - user
-id: node.article.teaser
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: node.article.sub_article
 targetEntityType: node
 bundle: article
-mode: teaser
+mode: sub_article
 content:
-  field_summary:
-    type: text_default
+  field_appeals:
     weight: 1
-    region: content
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-  field_thumbnail_image:
-    type: entity_reference_entity_view
-    weight: 0
-    region: content
     label: hidden
     settings:
-      view_mode: thumbnail_medium
+      view_mode: default
       link: false
     third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+  field_author:
+    type: entity_reference_entity_view
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_hero_image:
+    type: entity_reference_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: hero_image
+      link: false
+    third_party_settings: {  }
+    region: content
+  field_paragraphs:
+    weight: 3
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: layout_paragraphs
+    region: content
 hidden:
-  field_appeals: true
-  field_author: true
   field_further_reading: true
-  field_hero_image: true
-  field_paragraphs: true
   field_related_articles: true
   field_section: true
+  field_summary: true
+  field_thumbnail_image: true
   langcode: true
   links: true

--- a/config/core.entity_view_display.paragraph.sub_article.default.yml
+++ b/config/core.entity_view_display.paragraph.sub_article.default.yml
@@ -1,0 +1,22 @@
+uuid: 7396a45d-3b11-4fe1-8e2b-44274a6ffc40
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.sub_article.field_article
+    - paragraphs.paragraphs_type.sub_article
+id: paragraph.sub_article.default
+targetEntityType: paragraph
+bundle: sub_article
+mode: default
+content:
+  field_article:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: sub_article
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden: {  }

--- a/config/core.entity_view_display.taxonomy_term.section.default.yml
+++ b/config/core.entity_view_display.taxonomy_term.section.default.yml
@@ -1,0 +1,14 @@
+uuid: 5c4f0ee7-65c6-4e04-b09d-fdc37d67d927
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.section
+id: taxonomy_term.section.default
+targetEntityType: taxonomy_term
+bundle: section
+mode: default
+content: {  }
+hidden:
+  description: true
+  langcode: true

--- a/config/core.entity_view_mode.node.sub_article.yml
+++ b/config/core.entity_view_mode.node.sub_article.yml
@@ -1,0 +1,10 @@
+uuid: a6731025-7456-4223-abca-4f8a85f6d199
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.sub_article
+label: Sub-article
+targetEntityType: node
+cache: true

--- a/config/field.field.node.article.field_section.yml
+++ b/config/field.field.node.article.field_section.yml
@@ -1,0 +1,29 @@
+uuid: 86158704-01af-44ce-83f5-5be6d626672d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_section
+    - node.type.article
+    - taxonomy.vocabulary.section
+id: node.article.field_section
+field_name: field_section
+entity_type: node
+bundle: article
+label: Section
+description: 'Section the article belongs to. (Ex: Part one: Humanitarian Trends).'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      section: section
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.paragraph.sub_article.field_article.yml
+++ b/config/field.field.paragraph.sub_article.field_article.yml
@@ -1,0 +1,29 @@
+uuid: 215871cb-c2c1-4251-8e78-64112d89bf81
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_article
+    - node.type.article
+    - paragraphs.paragraphs_type.sub_article
+id: paragraph.sub_article.field_article
+field_name: field_article
+entity_type: paragraph
+bundle: sub_article
+label: Article
+description: 'Enter the title of the Article.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      article: article
+    sort:
+      field: title
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.storage.node.field_section.yml
+++ b/config/field.storage.node.field_section.yml
@@ -1,0 +1,20 @@
+uuid: 847b3e0a-5f8d-4f64-a707-25fa0bf3f260
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_section
+field_name: field_section
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_article.yml
+++ b/config/field.storage.paragraph.field_article.yml
@@ -1,0 +1,20 @@
+uuid: 39be9887-b64f-48f7-a8f8-bc1b8fce2890
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_article
+field_name: field_article
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/image.style.hero_desktop_x1.yml
+++ b/config/image.style.hero_desktop_x1.yml
@@ -5,12 +5,12 @@ dependencies: {  }
 name: hero_desktop_x1
 label: 'hero desktop x1'
 effects:
-  9e245c32-fb3b-42d1-a72b-ae52a85a7762:
-    uuid: 9e245c32-fb3b-42d1-a72b-ae52a85a7762
-    id: image_scale_and_crop
-    weight: 1
+  54e5c050-e5ac-4234-9da2-70638804ebb4:
+    uuid: 54e5c050-e5ac-4234-9da2-70638804ebb4
+    id: image_scale
+    weight: 2
     data:
       width: 976
-      height: 267
-      anchor: center-center
+      height: null
+      upscale: true
 pipeline: __default__

--- a/config/image.style.hero_desktop_x2.yml
+++ b/config/image.style.hero_desktop_x2.yml
@@ -5,12 +5,12 @@ dependencies: {  }
 name: hero_desktop_x2
 label: 'hero desktop x2'
 effects:
-  a50b2bb1-d142-48bb-a1fc-0e6bc4d8d61c:
-    uuid: a50b2bb1-d142-48bb-a1fc-0e6bc4d8d61c
-    id: image_scale_and_crop
-    weight: 1
+  a68aae79-6ee2-4885-b758-0a4554997d6d:
+    uuid: a68aae79-6ee2-4885-b758-0a4554997d6d
+    id: image_scale
+    weight: 2
     data:
       width: 1952
-      height: 534
-      anchor: center-center
+      height: null
+      upscale: true
 pipeline: __default__

--- a/config/image.style.hero_xlarge_x1.yml
+++ b/config/image.style.hero_xlarge_x1.yml
@@ -5,12 +5,12 @@ dependencies: {  }
 name: hero_xlarge_x1
 label: 'hero xlarge x1'
 effects:
-  321e376a-e7ae-4bb6-9a5a-cee879e583ba:
-    uuid: 321e376a-e7ae-4bb6-9a5a-cee879e583ba
-    id: image_scale_and_crop
-    weight: 1
+  b16fa3ca-93e8-45d3-bc62-5526d67bd2f8:
+    uuid: b16fa3ca-93e8-45d3-bc62-5526d67bd2f8
+    id: image_scale
+    weight: 2
     data:
       width: 1140
-      height: 312
-      anchor: center-center
+      height: null
+      upscale: true
 pipeline: __default__

--- a/config/image.style.hero_xlarge_x2.yml
+++ b/config/image.style.hero_xlarge_x2.yml
@@ -5,12 +5,12 @@ dependencies: {  }
 name: hero_xlarge_x2
 label: 'hero xlarge x2'
 effects:
-  09ac5563-29a0-49ff-a0fc-f09d6b781bb5:
-    uuid: 09ac5563-29a0-49ff-a0fc-f09d6b781bb5
-    id: image_scale_and_crop
-    weight: 1
+  44268e81-0087-4d22-9c6b-ec46adec18c5:
+    uuid: 44268e81-0087-4d22-9c6b-ec46adec18c5
+    id: image_scale
+    weight: 2
     data:
       width: 2280
-      height: 624
-      anchor: center-center
+      height: null
+      upscale: true
 pipeline: __default__

--- a/config/language.content_settings.taxonomy_term.section.yml
+++ b/config/language.content_settings.taxonomy_term.section.yml
@@ -1,0 +1,16 @@
+uuid: ac07143a-7acc-4dbf-9e1e-6426a5c6e6a1
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.section
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.section
+target_entity_type_id: taxonomy_term
+target_bundle: section
+default_langcode: site_default
+language_alterable: false

--- a/config/paragraphs.paragraphs_type.sub_article.yml
+++ b/config/paragraphs.paragraphs_type.sub_article.yml
@@ -1,0 +1,10 @@
+uuid: aad0adc9-ea9e-44ae-8690-5eaaf50002d3
+langcode: en
+status: true
+dependencies: {  }
+id: sub_article
+label: Sub-article
+icon_uuid: null
+icon_default: null
+description: 'A paragraph showing a sub-article.'
+behavior_plugins: {  }

--- a/config/taxonomy.vocabulary.section.yml
+++ b/config/taxonomy.vocabulary.section.yml
@@ -1,0 +1,8 @@
+uuid: 9ec321be-0357-4971-9150-7d60ac0f8cc3
+langcode: en
+status: true
+dependencies: {  }
+name: Section
+vid: section
+description: 'Sections to which articles belong.'
+weight: 0

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -73,3 +73,21 @@ gho-aside:
       components/gho-aside/gho-aside.css: {}
   dependencies:
     - common_design_subtheme/gho-bleed
+
+gho-hero-image:
+   css:
+     theme:
+       components/gho-hero-image/gho-hero-image.css: {}
+   dependencies:
+     - common_design_subtheme/gho-bleed
+
+gho-article:
+   css:
+     theme:
+       components/gho-article/gho-article.css: {}
+
+gho-sub-article:
+   css:
+     theme:
+       components/gho-sub-article/gho-sub-article.css: {}
+

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -92,6 +92,24 @@ function common_design_subtheme_add_component_classes($html, array $element) {
 }
 
 /**
+ * Implements hook_preprocess_paragraph__needs_and_requirements().
+ *
+ * Pre-render the needs and requirements to avoid Drupal crashing without any
+ * error messages (nginx 502) when rendering the content in a twig template,
+ * probably due to too many nested entity references.
+ *
+ * @todo check if wee need to do something about the cache.
+ */
+function common_design_subtheme_preprocess_paragraph__needs_and_requirements(&$variables) {
+  if (isset($variables['content']['field_needs_and_requirements'][0])) {
+    $content = $variables['content']['field_needs_and_requirements'][0];
+    $variables['content'] = [
+      ['#markup' => \Drupal::service('renderer')->render($content)],
+    ];
+  }
+}
+
+/**
  * Implements hook_preprocess_paragraph__page_title().
  *
  * Use the page title block for the title and display the local tasks below it.
@@ -111,12 +129,31 @@ function common_design_subtheme_preprocess_paragraph__page_title(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_node__article().
+ *
+ * Use the page title block for the title and display the local tasks below it.
+ * We use common_design_subtheme_get_block_render_array() that will cache the
+ * render array of the blocks so that they are not re-rendered and displayed
+ * again.
+ *
+ * @see common_design_subtheme_preprocess_page()
+ * @see common_design_subtheme_get_block_render_array()
+ */
+function common_design_subtheme_preprocess_node__article(&$variables) {
+  if (isset($variables['view_mode']) && $variables['view_mode'] === 'full') {
+    $variables['title'] = common_design_subtheme_get_block_render_array('page_title_block');
+    $variables['local_tasks'] = common_design_subtheme_get_block_render_array('local_tasks_block');
+  }
+}
+
+/**
  * Implements hook_preprocess_page().
  *
  * Remove the default page title and local tasks blocks if they were already
- * rendered by a page title paragraph.
+ * rendered by a page title paragraph or when viewing full article nodes.
  *
  * @see common_design_subtheme_preprocess_paragraph__page_title()
+ * @see common_design_subtheme_preprocess_node__article()
  */
 function common_design_subtheme_preprocess_page(&$variables) {
   if (isset($variables['node'])) {

--- a/html/themes/custom/common_design_subtheme/components/gho-article/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-article/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Article Component
+================================================
+
+Styling for the articles when viewed in full mode for example.

--- a/html/themes/custom/common_design_subtheme/components/gho-article/gho-article.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article/gho-article.css
@@ -1,0 +1,49 @@
+/* Make sure the image is attached to the botton of the header. */
+.gho-article {
+  margin-top: -2rem;
+}
+@media (min-width: 768px) {
+  .gho-article {
+    margin-top: -3rem;
+  }
+}
+
+.gho-article__header {
+  position: relative;
+}
+.gho-article__heading {
+  padding: 2rem 0 0 0;
+}
+@media (min-width: 1200px) {
+  .gho-article--with-hero-image .gho-article__heading {
+    position: absolute;
+    bottom: 0;
+    left: -2rem;
+    right: -2rem;
+    padding: 1rem 2rem;
+    background: white;
+  }
+}
+
+.gho-article__pre-title {
+  max-width: 480px;
+  margin-bottom: 0.5rem;
+  color: #6d6d6d;
+}
+.gho-article .page-title {
+  max-width: 480px;
+  padding: 0;
+  margin: 0;
+  border: none;
+  font-size: 2.625rem;
+  color: black;
+}
+@media (min-width: 768px) {
+  .gho-article .page-title {
+    font-size: 3.25rem;
+  }
+}
+
+.gho-article .gho-article__local_tasks {
+  margin-top: 2rem;
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-hero-image/gho-hero-image.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-hero-image/gho-hero-image.css
@@ -2,14 +2,10 @@
  * @file
  * Styling for the Hero Image.
  */
-
-/* Make sure the image is attached to the botton of the header. */
-.gho-hero-image {
-  margin-top: -2rem;
-  margin-bottom: 1.5rem;
+.gho-hero-image.gho-bleed {
+  padding: 0;
 }
-@media (min-width: 768px) {
-  .gho-hero-image {
-    margin-top: -3rem;
-  }
+.gho-hero-image img {
+  display: block;
+  width: 100%;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-sub-article/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-sub-article/README.md
@@ -1,0 +1,6 @@
+Global Humanitarian Overview - Sub-Article Component
+====================================================
+
+When several Articles are nested onto one URL, we render them as Sub-Articles
+with slightly different visual treatment for the main fields such as Hero image,
+Further Reading, Related Articles. The Paragraphs content is untouched.

--- a/html/themes/custom/common_design_subtheme/components/gho-sub-article/gho-sub-article.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-sub-article/gho-sub-article.css
@@ -1,0 +1,33 @@
+/**
+ * Base styles
+ */
+.gho-sub-article__header {
+  margin: 2rem 0 ;
+  padding: 2rem 0 0 0;
+  border-top: 1px solid #ccc;
+}
+.gho-sub-article--with-hero-image .gho-sub-article__header {
+  margin-top: 2rem;
+  padding-top: 0;
+  border-top: none;
+}
+.gho-sub-article--with-hero-image .gho-hero-image {
+  margin-bottom: 2rem;
+}
+.gho-sub-article__title {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  color: black;
+  font-size: 2rem;
+  font-weight: 700;
+}
+.gho-sub-article .gho-appeals-tags {
+  display: inline;
+  vertical-align: top;
+}
+@media (min-width: 768px) {
+  .gho-sub-article__title {
+    font-size: 2.625rem;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-hero-image--article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-hero-image--article.html.twig
@@ -1,0 +1,84 @@
+{#
+/**
+ * @file
+ * Theme override for a Hero Image field on an Article.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-hero-image') }}
+{%
+  set classes = [
+    'field',
+    'field--name-' ~ field_name|clean_class,
+    'field--type-' ~ field_type|clean_class,
+    'field--label-' ~ label_display,
+    label_display == 'inline' ? 'clearfix',
+    'gho-hero-image',
+    'gho-bleed',
+  ]
+%}
+{%
+  set title_classes = [
+    'field__label',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes.addClass(classes, 'field__items') }}>
+      {% for item in items %}
+        <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass(classes, 'field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes.addClass(classes) }}>
+    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+    {% if multiple %}
+      <div class="field__items">
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-section--article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-section--article.html.twig
@@ -1,0 +1,46 @@
+{#
+/**
+ * @file
+ * Theme override for the Section field on Articles.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% spaceless %}
+<div class="gho-article__pre-title">
+  {% for item in items %}
+  {{ item.content }}
+  {% endfor %}
+</div>
+{% endspaceless %}

--- a/html/themes/custom/common_design_subtheme/templates/media/media.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/media/media.html.twig
@@ -1,0 +1,31 @@
+{#
+/**
+ * @file
+ * Theme override to display a media item.
+ *
+ * Change the `article` markup to `div` as it doesn't make so much semantic
+ * sense.
+ *
+ * Available variables:
+ * - name: Name of the media.
+ * - content: Media content.
+ *
+ * @see template_preprocess_media()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'media',
+    'media--type-' ~ media.bundle()|clean_class,
+    not media.isPublished() ? 'media--unpublished',
+    view_mode ? 'media--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_suffix.contextual_links }}
+  {% if content %}
+    {{ content }}
+  {% endif %}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--full.html.twig
@@ -1,7 +1,11 @@
 {#
 /**
  * @file
- * Theme override to display an Article node using Related Article view mode.
+ * Theme override to display an Article node in Full view mode.
+ *
+ * Note: there is a hook_preprocess_node__article() that adds those variables:
+ * - title: node title
+ * - local_tasks: local tasks (edit etc.)
  *
  * Available variables:
  * - node: The node entity with limited access to object properties and methods.
@@ -70,7 +74,10 @@
  *   in different view modes.
  */
 #}
-{{ attach_library('common_design_subtheme/gho-related-article') }}
+{{ attach_library('common_design_subtheme/gho-article') }}
+{%
+  set hero_image = content.field_hero_image|render
+%}
 {%
   set classes = [
     'node',
@@ -79,15 +86,23 @@
     node.isSticky() ? 'node--sticky',
     not node.isPublished() ? 'node--unpublished',
     view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
-    'gho-related-article',
+    'gho-article',
+    hero_image ? 'gho-article--with-hero-image',
     'clearfix',
   ]
 %}
 <article{{ attributes.addClass(classes) }}>
-  <h3{{ title_attributes.addClass('gho-related-article__title') }}>
-    <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-  </h3>
-
-  {{ content }}
-  <a href="{{ url }}" class="read-article">{{ 'Read article'|t }}</a>
+  <header class="gho-article__header">
+    {{ hero_image }}
+    <div class="gho-article__heading">
+      {{ content.field_section }}
+      {{ title }}
+    </div>
+  </header>
+  {% if local_tasks %}
+  <div class="gho-article__local_tasks clearfix">{{ local_tasks }}</div>
+  {% endif %}
+  <div{{ content_attributes.addClass('node__content') }}>
+    {{ content|without(['field_hero_image', 'field_section']) }}
+  </div>
 </article>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--sub-article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--sub-article.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display an Article node using Related Article view mode.
+ * Theme override to display an Article node in Sub-Article view mode.
  *
  * Available variables:
  * - node: The node entity with limited access to object properties and methods.
@@ -70,7 +70,10 @@
  *   in different view modes.
  */
 #}
-{{ attach_library('common_design_subtheme/gho-related-article') }}
+{{ attach_library('common_design_subtheme/gho-sub-article') }}
+{%
+  set hero_image = content.field_hero_image|render
+%}
 {%
   set classes = [
     'node',
@@ -79,15 +82,18 @@
     node.isSticky() ? 'node--sticky',
     not node.isPublished() ? 'node--unpublished',
     view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
-    'gho-related-article',
+    'gho-sub-article',
+    hero_image ? 'gho-sub-article--with-hero-image',
     'clearfix',
   ]
 %}
 <article{{ attributes.addClass(classes) }}>
-  <h3{{ title_attributes.addClass('gho-related-article__title') }}>
-    <a href="{{ url }}" rel="bookmark">{{ label }}</a>
-  </h3>
-
-  {{ content }}
-  <a href="{{ url }}" class="read-article">{{ 'Read article'|t }}</a>
+  <header class="gho-sub-article__header">
+    {{ hero_image }}
+    <h2{{ title_attributes.addClass('gho-sub-article__title') }}>{{ label }}</h2>
+    {{ content.field_appeals }}
+  </header>
+  <div{{ content_attributes.addClass('node__content') }}>
+    {{ content|without(['field_hero_image', 'field_appeals']) }}
+  </div>
 </article>

--- a/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--needs-and-requirements.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/taxonomy/taxonomy-term--needs-and-requirements.html.twig
@@ -3,6 +3,10 @@
  * @file
  * Theme override to display a "needs and requirements" taxonomy term.
  *
+ * Note: the content is pre-rendered in a hook_preprocess() to avoid Drupal
+ * from crashing without errors (nginx 502) when rendering the content in the
+ * template, probably due to too many nested entity references.
+ *
  * Available variables:
  * - url: URL of the current term.
  * - name: (optional) Name of the current term.


### PR DESCRIPTION
Ticket: GHO-47, GHO-35, GHO-51, GHO-52

This is a replacement of https://github.com/UN-OCHA/gho-site/pull/42, porting some of its changes.

This also include the addition of a new "section" field and it's associated vocabulary (GHO-35) and hero image styling (GHO-51) as well as "appeals" styling (GHO-52). It would have probably been better to separate in separate PRs but this makes it easier to implement the sub-article.

So this PR includes:

- Section vocabulary (ex: Part one: Humanitarian Trends), section field on articles and styling when shown with the `<h1>` on article pages.
- Sub-article paragraph type which references other articles.
- Article, sub-article and hero image css components. The sub-article component also handle "Appeals" which are basically just sub-articles without a hero image and the appeals tagged displayed.
- Some preprocess hooks to add the node `title` as variable usable in the twig templates for easier styling of the article pages and to pre-render the "needs and requirements" that cause Drupal to crash when rendered inside a twig template (nginx 502).

## Hero images

### Article pages

For article **pages**, the title overlaps with the hero image on large screens:

<img width="765" alt="Screen Shot 2020-11-02 at 15 16 21" src="https://user-images.githubusercontent.com/696348/97835842-66737880-1d1e-11eb-95bc-48fb32f8251e.png">

The title is displayed below the hero image on smaller screens:

<img width="594" alt="Screen Shot 2020-11-02 at 15 17 51" src="https://user-images.githubusercontent.com/696348/97835928-9a4e9e00-1d1e-11eb-9063-1d7c1e176598.png">

### Sub articles

The hero image is displayed above the title of the sub-article regardless of the screen size:

<img width="747" alt="Screen Shot 2020-11-02 at 15 19 00" src="https://user-images.githubusercontent.com/696348/97836040-c538f200-1d1e-11eb-8baf-120d3c4959a3.png">

**Note:** When there is no hero image (for example for "Appeals" articles), a border above the title is displayed:

<img width="711" alt="Screen Shot 2020-11-02 at 15 20 32" src="https://user-images.githubusercontent.com/696348/97836140-f74a5400-1d1e-11eb-942f-0a637d9eaf73.png">

### Image styles

The image styles for the hero images are quite off I think, notably on smaller screens and will need to be adjusted in another PR.

## Appeals

There is no special styling for "Appeals" articles. I'm assuming they will not have a hero image and so a simple border above the title and will be tagged with some appeals which will appear next to the title when displayed as sub-articles:

<img width="640" alt="Screen Shot 2020-11-02 at 15 23 13" src="https://user-images.githubusercontent.com/696348/97836309-5c05ae80-1d1f-11eb-9280-b87fa2530430.png">


## TODO

- Review the styling of the titles, notably the font-size at different screen size.
- Adjust the image styles for the  hero image.
- Find a proper way to display the credits and caption for the hero image.

## Testing

- `Drush cim` and `drush cr`
- Create `section` terms
- Create `appeals` terms if not already there
- Create articles, stories etc.
- Add sub-articles to the relevant "main" articles.


