### PR TITLE
[GHO-11] Fix bottom figures left/right padding

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
@@ -1,6 +1,11 @@
 /**
- * Base field
+ * Base field.
  */
+.gho-bottom-figure-row {
+  /* Same margins as the aside components for consistency. */
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
 .gho-bottom-figure-row .field__items {
   display: flex;
   flex-flow: row wrap;
@@ -16,15 +21,17 @@
 }
 [dir='ltr'] .gho-bottom-figure-row .field__items > .field__item {
   /* The left margin combined with the overflow-x: hidden of the parent
-   * ensures the border is hidden for the first item of each row. */
-  margin-left: -1px;
+   * ensures the left border and padding are hidden for the first item of each
+   * row. */
+  margin-left: calc(-1rem - 1px);
   padding: 0 2rem 0 1rem;
   border-left: 1px solid #ddd;
 }
 [dir='rtl'] .gho-bottom-figure-row .field__items > .field__item {
   /* The right margin combined with the overflow-x: hidden of the parent
-   * ensures the border is hidden for the first item of each row. */
-  margin-right: -1px;
+   * ensures the right border and padding are hidden for the first item of each
+   * row. */
+  margin-right: calc(-1rem - 1px);
   padding: 0 1rem 0 2rem;
   border-right: 1px solid #ddd;
 }
@@ -49,11 +56,5 @@
 
 .gho-bottom-figure-row .gho-dataset-link {
   padding-top: 1rem;
-  padding-left: 1rem;
   border-top: 1px solid #ddd;
-}
-
-[dir='rtl'] .gho-bottom-figure-row .gho-dataset-link {
-  padding-left: 0;
-  padding-right: 1rem;
 }


### PR DESCRIPTION
Ticket: GHO-11

According to the PDF, there is no padding left (or right on RTL) for the bottom figures:

PDF:

<img width="508" alt="Screen Shot 2020-11-02 at 19 25 18" src="https://user-images.githubusercontent.com/696348/97858179-1ad2c600-1d42-11eb-8f94-211e1d163238.png">

PR:

<img width="590" alt="Screen Shot 2020-11-02 at 19 30 55" src="https://user-images.githubusercontent.com/696348/97858195-20c8a700-1d42-11eb-8ac1-133891f76b7e.png">
<img width="444" alt="Screen Shot 2020-11-02 at 19 31 08" src="https://user-images.githubusercontent.com/696348/97858199-21f9d400-1d42-11eb-9e9f-a38b3080c8d4.png">
