### PR TITLE
Restore admin styles for Facts and Figures paragraph type

### DIFF
--- a/html/themes/custom/common_design_admin_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_admin_subtheme/css/styles.css
@@ -36,21 +36,21 @@
 /*------------------------------------------------------------------------------
  * Styling of the Facts and Figures paragraph type
  *----------------------------------------------------------------------------*/
-.paragraph--type--facts-and-figures.paragraph--view-mode--three-columns {
+.paragraph--type--facts-and-figures {
   background: #222;
   color: white;
   padding: 1em;
 }
-.paragraph--type--facts-and-figures.paragraph--view-mode--three-columns .field--name-field-title {
+.paragraph--type--facts-and-figures .field--name-field-title {
   padding-bottom: 1em;
   margin: 0;
 }
-.paragraph--type--facts-and-figures.paragraph--view-mode--three-columns .field--name-field-paragraphs {
+.paragraph--type--facts-and-figures .field--name-field-paragraphs {
   display: flex;
   flex-flow: row wrap;
   margin: 0 -.5em;
 }
-.paragraph--type--facts-and-figures.paragraph--view-mode--three-columns .field--name-field-paragraphs > .field__item {
+.paragraph--type--facts-and-figures .field--name-field-paragraphs > .field__item {
   flex: 0 0 32%;
   padding: 0 .5em;
 }


### PR DESCRIPTION
No ticket, but while auditing the image aspect ratios I noticed these styles got dropped when we set the three-col view mode to  be default.