### PR TITLE
[GHO-16] photo gallery pt3

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/gho-photo-gallery.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/gho-photo-gallery.css
@@ -43,6 +43,10 @@
     justify-content: space-around;
   }
   .gho-photo-gallery--two-columns .field--name-field-photos > .field__item {
-    flex: 0 0 50%;
+    /* To maintain IE11 compat, do NOT use shorthand because calc cannot be
+       recognized by IE 10-11 within the `flex` shorthand property */
+    flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: calc(50% - 1rem);
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/gho-photo-gallery.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/gho-photo-gallery.css
@@ -9,8 +9,11 @@
   padding: 0.5rem;
 }
 .gho-photo-gallery__location {
-  font-weight: bold;
   margin-bottom: 0;
+  font-weight: bold;
+}
+.gho-photo-gallery__caption {
+  margin-top: 0;
 }
 .gho-photo-gallery__credits {
   font-style: italic;


### PR DESCRIPTION
# GHO-16

Follow-ups for #59 

- IE11 photo grallery layout fixed. [Details if you want them](https://stackoverflow.com/a/52669657).
- Location/Caption had space re-introduced, I presume when we shuffled the markup around and stopped using `display:inline` on caption directly.