### PR TITLE
GHO-33: multimedia credit field

### DIFF
--- a/config/core.entity_form_display.media.video.media_library.yml
+++ b/config/core.entity_form_display.media.video.media_library.yml
@@ -12,6 +12,14 @@ targetEntityType: media
 bundle: video
 mode: media_library
 content:
+  field_credits:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   name:
     type: string_textfield
     settings:
@@ -22,7 +30,6 @@ content:
     region: content
 hidden:
   created: true
-  field_credits: true
   field_media_oembed_video: true
   langcode: true
   path: true

--- a/config/field.field.node.story.field_media.yml
+++ b/config/field.field.node.story.field_media.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: story
 label: Media
 description: 'Media used to illustrate the story. It can be an image, a video or an embedded content (infographic etc.).'
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
# GHO-33

Small improvements to the work in #61 to surface the credit field, and also mark the Image/Video as required when creating a Story entity. The config screen I finally found:

![image](https://user-images.githubusercontent.com/254753/98273798-f3266c80-1f92-11eb-9e59-579e1b9dab00.png)

And the new upload form with required Credits field:

![image](https://user-images.githubusercontent.com/254753/98273868-0df8e100-1f93-11eb-817b-bb28929ee06e.png)


