### PR TITLE
[OPS-6971] Allow HID logins during maintenance mode, so we can test and populate prod with content.

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -7,6 +7,9 @@
         "drupal/entity_usage": {
             "https://www.drupal.org/project/entity_usage/issues/2955078": "https://www.drupal.org/files/issues/2018-04-06/2955078-5.patch"
         },
+        "drupal/social_auth_hid" : {
+            "Optionally allow HID logins during maintenance" : "https://www.drupal.org/files/issues/2020-11-10/3181583-hid-maintenance-logins-2.patch"
+        },
         "drupal/yaml_content" : {
             "https://www.drupal.org/project/yaml_content/issues/3084161": "https://www.drupal.org/files/issues/2020-04-10/yaml_content-layout-builder-support-3084161-8.patch"
         }

--- a/config/social_auth_hid.settings.yml
+++ b/config/social_auth_hid.settings.yml
@@ -8,3 +8,4 @@ client_secret: HID_CLIENT_SECRET_DO_NOT_COMMIT_TO_REPOSITORY
 disable_password_fields: true
 disable_email_field: true
 disable_user_field: true
+maintenance_access: true

--- a/config/user.role.administrator.yml
+++ b/config/user.role.administrator.yml
@@ -10,6 +10,7 @@ permissions:
   - 'access administration pages'
   - 'access content overview'
   - 'access media overview'
+  - 'access site in maintenance mode'
   - 'access taxonomy overview'
   - 'access toolbar'
   - 'access user profiles'


### PR DESCRIPTION
This should maybe eventually go into social_auth_hid with a setting to turn it off or on.