### PR TITLE
[GHO-25] Language visibility

### DIFF
--- a/config/core.entity_form_display.node.article.home_page.yml
+++ b/config/core.entity_form_display.node.article.home_page.yml
@@ -1,0 +1,96 @@
+uuid: 713e381c-11b6-4056-ab08-9ccb00957e26
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.node.home_page
+    - field.field.node.article.field_appeals
+    - field.field.node.article.field_author
+    - field.field.node.article.field_hero_image
+    - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_report_link
+    - field.field.node.article.field_section
+    - field.field.node.article.field_summary
+    - field.field.node.article.field_thumbnail_image
+    - node.type.article
+  module:
+    - layout_paragraphs
+    - link
+    - media_library
+    - text
+id: node.article.home_page
+targetEntityType: node
+bundle: article
+mode: home_page
+content:
+  field_hero_image:
+    type: media_library_widget
+    weight: 3
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    region: content
+  field_paragraphs:
+    weight: 5
+    settings:
+      preview_view_mode: default
+      nesting_depth: 4
+      require_layouts: 0
+    third_party_settings: {  }
+    type: layout_paragraphs
+    region: content
+  field_report_link:
+    weight: 2
+    settings:
+      placeholder_url: 'Ex: https://reliefweb.int/gho-2020.pdf'
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_section:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_summary:
+    weight: 4
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  promote:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 7
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_appeals: true
+  field_author: true
+  field_thumbnail_image: true
+  langcode: true
+  path: true
+  sticky: true
+  translation: true
+  uid: true
+  url_redirects: true

--- a/config/core.entity_form_mode.node.home_page.yml
+++ b/config/core.entity_form_mode.node.home_page.yml
@@ -1,0 +1,10 @@
+uuid: 70058e23-3011-41a0-8e20-24e0cbb7f6f3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.home_page
+label: 'Home page'
+targetEntityType: node
+cache: true

--- a/config/user.role.administrator.yml
+++ b/config/user.role.administrator.yml
@@ -54,6 +54,7 @@ permissions:
   - 'revert all revisions'
   - 'revert article revisions'
   - 'revert story revisions'
+  - 'translate any entity'
   - 'update any media'
   - 'update media'
   - 'use text format filtered_html'

--- a/config/user.role.administrator.yml
+++ b/config/user.role.administrator.yml
@@ -54,7 +54,6 @@ permissions:
   - 'revert all revisions'
   - 'revert article revisions'
   - 'revert story revisions'
-  - 'translate any entity'
   - 'update any media'
   - 'update media'
   - 'use text format filtered_html'
@@ -67,3 +66,4 @@ permissions:
   - 'view published document media'
   - 'view story revisions'
   - 'view the administration theme'
+  - 'view untranslated content'

--- a/html/modules/custom/gho_access/README.md
+++ b/html/modules/custom/gho_access/README.md
@@ -38,3 +38,13 @@ Roles
 
 This module also provides a permission to assign user roles, decoupling it
 from the `administer permissions` permission.
+
+Language
+--------
+
+This module ensures that content in a language is only displayed when the
+homepage in that language is published and "promoted". It also ensures that
+there is no mix of content in different languages due to Drupal's behavior to
+show content in the default language when no translation is available.
+People with the `view untranslated content` permission can always see any
+content even if it doesn't match the current language.

--- a/html/modules/custom/gho_access/gho_access.module
+++ b/html/modules/custom/gho_access/gho_access.module
@@ -8,8 +8,11 @@
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\block\BlockInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
 
 /**
  * Implements hook_node_access().
@@ -26,6 +29,8 @@ function gho_access_node_access(NodeInterface $node, $operation, AccountInterfac
       if ($published && !$account->hasPermission("view published {$type} content")) {
         return AccessResult::forbidden()->cachePerPermissions();
       }
+      // Check the access to the translation.
+      return gho_access_check_node_language_access($node, $account);
   }
   // No opinion, let other modules handle the permissions.
   return AccessResult::neutral();
@@ -46,6 +51,24 @@ function gho_access_media_access(MediaInterface $media, $operation, AccountInter
       if ($published && !$account->hasPermission("view published {$type} media")) {
         return AccessResult::forbidden()->cachePerPermissions();
       }
+      // Check the access to the translation.
+      return gho_access_check_language_access($media, $account);
+  }
+  // No opinion, let other modules handle the permissions.
+  return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_taxonomy_term_access().
+ *
+ * Deny view access to users without the view published 'media bundle' content
+ * permission.
+ */
+function gho_access_taxonomy_term_access(TermInterface $term, $operation, AccountInterface $account) {
+  switch ($operation) {
+    case 'view':
+      // Check the access to the translation.
+      return gho_access_check_language_access($term, $account);
   }
   // No opinion, let other modules handle the permissions.
   return AccessResult::neutral();
@@ -64,4 +87,121 @@ function gho_access_form_user_form_alter(&$form, FormStateInterface $form_state,
   $roles_access = !empty($form['account']['roles']['#options']) &&
                   \Drupal::currentUser()->hasPermission('assign user roles');
   $form['account']['roles']['#access'] = $roles_access;
+}
+
+/**
+ * Implements  hook_block_access().
+ *
+ * Hide the main menu if the language visibility for the current language is
+ * not enabled.
+ */
+function gho_access_block_access(BlockInterface $block, $operation, AccountInterface $account) {
+  if ($operation === 'view' && $block->id() === 'mainnavigation') {
+    return gho_access_check_language_access(NULL, $account);
+  }
+
+  // No opinion, let other modules handle the permissions.
+  return AccessResult::neutral();
+}
+
+/**
+ * Check if an account is allowed to view a node in the current language.
+ *
+ * @param \Drupal\node\NodeInterface $node
+ *   Node to check access for.
+ * @param \Drupal\Core\Session\AccountInterface $account
+ *   User account.
+ *
+ * @return \Drupal\Core\Access\AccessResult
+ *   Access result: either neutral if the account is allowed to access the
+ *   content or forbidden otherwise.
+ */
+function gho_access_check_node_language_access(NodeInterface $node, AccountInterface $account) {
+  // Skip access for the homepage or the node corresponding to the current
+  // request because its access is checked at the route level.
+  //
+  // @see Drupal\gho_access\Access\GhoLanguageVisibilityAccessCheck::access()
+  $nid = \Drupal::service('current_route_match')->getRawParameter('node');
+  if ($nid === NULL || $nid == 1 || $nid == $node->id()) {
+    // Let other module decide the access to the node.
+    return AccessResult::neutral();
+  }
+
+  return gho_access_check_language_access($node, $account);
+}
+
+/**
+ * Check if an account is allowed to view content in the current language.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface|null $entity
+ *   Optional entity to check access for.
+ * @param \Drupal\Core\Session\AccountInterface $account
+ *   User account.
+ *
+ * @return \Drupal\Core\Access\AccessResult
+ *   Access result: either neutral if the account is allowed to access the
+ *   content or forbidden otherwise.
+ */
+function gho_access_check_language_access(?EntityInterface $entity, AccountInterface $account) {
+  // Get the current language.
+  $langcode = \Drupal::service('language_manager')->getCurrentLanguage()->getId();
+
+  // Do not deny access if the user has the permission to view any content
+  // regardless of the status if its translation.
+  if ($account->hasPermission('view untranslated content')) {
+    // We let other modules decide the access to the entity.
+    $access = AccessResult::neutral();
+  }
+  // If there is a mismatch between the current language and the entity language
+  // we deny access.
+  elseif (isset($entity) && $entity->language()->getId() !== $langcode) {
+    $access = AccessResult::forbidden();
+  }
+  // Otherwise we check if the visibility for the language is enabled by
+  // looking at the status of the homepage in that language.
+  elseif (gho_access_check_language_visibility($langcode)) {
+    // We let other modules decide the access to the entity but we also make
+    // sure to clear the cache when the homepage is changed.
+    $access = AccessResult::neutral()->addCacheTags(['node:1']);
+  }
+  // If the homepage in the language doesn't exist or doesn't match the
+  // criteria, then we disallow access.
+  else {
+    // We deny access but we also make sure to clear the cache when the homepage
+    // is changed.
+    $access = AccessResult::forbidden()->addCacheTags(['node:1']);
+  }
+
+  // Ensure the cache is cleared when the permissions change.
+  return $access->cachePerPermissions();
+}
+
+/**
+ * Determine the language visibility from the homepage status.
+ *
+ * @param string $langcode
+ *   Language code to check.
+ *
+ * @return bool
+ *   Whether the homepage in the given language matches the conditions
+ *   (exists, published and promoted) to allow visibility of the language to
+ *   anonymous users.
+ */
+function gho_access_check_language_visibility($langcode) {
+  static $allowed = [];
+
+  // Check if there is homepage matching the conditions and store the result
+  // to avoid excessive queries as this can be called elsewhere.
+  if (!isset($allowed[$langcode])) {
+    $storage = \Drupal::service('entity_type.manager')->getStorage('node');
+    $ids = $storage->getQuery()
+      ->condition('nid', 1)
+      ->condition('langcode', $langcode)
+      ->condition('status', NodeInterface::PUBLISHED)
+      ->condition('promote', NodeInterface::PROMOTED)
+      ->execute();
+    $allowed[$langcode] = !empty($ids);
+  }
+
+  return $allowed[$langcode];
 }

--- a/html/modules/custom/gho_access/gho_access.permissions.yml
+++ b/html/modules/custom/gho_access/gho_access.permissions.yml
@@ -3,3 +3,7 @@ assign user roles:
   restrict access: true
 permission_callbacks:
   - \Drupal\gho_access\GhoAccessPermissions::buildPermissions
+
+view untranslated content:
+  title: 'View untranslated content'
+  description: "Allow access to content that has not yet been translated in the current language"

--- a/html/modules/custom/gho_access/gho_access.services.yml
+++ b/html/modules/custom/gho_access/gho_access.services.yml
@@ -1,0 +1,10 @@
+services:
+  gho_access.route_subscriber:
+    class: Drupal\gho_access\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
+  access_check.gho_language_visibility:
+    class: Drupal\gho_access\Access\GhoLanguageVisibilityAccessCheck
+    arguments: ['@current_route_match', '@language_manager']
+    tags:
+      - { name: access_check, applies_to: '_access_check_gho_language_visibility' }

--- a/html/modules/custom/gho_access/src/Access/GhoLanguageVisibilityAccessCheck.php
+++ b/html/modules/custom/gho_access/src/Access/GhoLanguageVisibilityAccessCheck.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\gho_access\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Http\Exception\CacheableNotFoundHttpException;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Check global language visibility to determine access to a node.
+ */
+class GhoLanguageVisibilityAccessCheck implements AccessInterface {
+
+  /**
+   * The route matching service.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a EntityCreateAccessCheck object.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route matching service.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * Check access to the node page.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The currently logged in account.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node that is being viewed.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account, NodeInterface $node) {
+    // Only check the route for the node matching the current request and also
+    // skip for the homepage and let other module handle the access checks and
+    // caching.
+    $nid = $this->routeMatch->getRawParameter('node');
+    if ($nid === NULL || $nid == 1 || $nid != $node->id()) {
+      return AccessResult::allowed();
+    }
+
+    // Check the node access for the current language.
+    $access = gho_access_check_language_access($node, $account);
+
+    // Ensure the cache gets cleared when the permissions or the node change.
+    $access->cachePerPermissions()->addCacheableDependency($node);
+
+    // For better UX, we throw a page not found instead of a 403 but make sure
+    // the response can be invalidated when the node, homepage or permissions
+    // change.
+    if ($access->isForbidden()) {
+      throw new CacheableNotFoundHttpException($access);
+    }
+
+    // Route access is different than node access and "neutral" results in
+    // forbidden acccess to we return a "allowed" inheriting the caching.
+    return AccessResult::allowed()->inheritCacheability($access);
+  }
+
+}

--- a/html/modules/custom/gho_access/src/Routing/RouteSubscriber.php
+++ b/html/modules/custom/gho_access/src/Routing/RouteSubscriber.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\gho_access\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Add a requirement to check the global language visibility for the
+    // GHO site, as first requirement.
+    if ($route = $collection->get('entity.node.canonical')) {
+      $requirements = ['_access_check_gho_language_visibility' => '{node}'];
+      $requirements += $route->getRequirements();
+      $route->setRequirements($requirements);
+    }
+  }
+
+}

--- a/html/modules/custom/gho_general/gho_general.module
+++ b/html/modules/custom/gho_general/gho_general.module
@@ -5,6 +5,9 @@
  * GHO General module file.
  */
 
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_element_info_alter().
  *
@@ -98,4 +101,40 @@ function gho_access_switch_to_language($langcode = '') {
   $translation_manager->setDefaultLangcode($language->getId());
 
   return $current_langcode;
+}
+
+/**
+ * Implements hook_entity_form_display_alter().
+ *
+ * Use the "homepage" form display mode for the home page.
+ */
+function gho_general_entity_form_display_alter(EntityFormDisplayInterface &$form_display, array $context) {
+  if ($context['entity_type'] === 'node' && $context['bundle'] === 'article') {
+    $nid = \Drupal::service('current_route_match')->getRawParameter('node');
+    // The homepage is node 1.
+    if ($nid == 1) {
+      $storage = \Drupal::service('entity_type.manager')->getStorage('entity_form_display');
+      $form_display = $storage->load('node.article.home_page');
+    }
+  }
+}
+
+/**
+ * Implements hook_form_node_article_edit_form_alter().
+ *
+ * Alter the promote for the homepage to indicate it controls the global
+ * visibility of the content for a given language.
+ */
+function gho_general_form_node_article_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $storage = $form_state->getStorage();
+  if (isset($storage['form_display'], $storage['langcode']) && $storage['form_display']->getMode() === 'home_page') {
+    $promote_title = t("Enable global visibility of @language content", [
+      '@language' => \Drupal::service('language_manager')
+        ->getLanguage($storage['langcode'])
+        ->getName(),
+    ]);
+    $form['promote']['#group'] = 'footer';
+    $form['promote']['widget']['#title'] = $promote_title;
+    $form['promote']['widget']['value']['#title'] = $promote_title;
+  }
 }


### PR DESCRIPTION
Ticket: GHO-25

**Background**: 

1. Drupal's default behavior is to display content in their default language when the translation is missing. So we end up, for example, with articles in Arabic with sub-articles in English because not yet translated.
2. It's been requested to be able to only show the homepage in Arabic for example while content in that language is being added to the site.

**Solution**

So this modules deals with dark magic to add access checks to allow the visibility of content in a given language (after a million of hours battling Drupal):

1. It defines a "view untranslated content" permission (given to admins) to allow to see content in any language regardless of the status of the translations. Said otherwise, if you have this permission, then you get the default Drupal's behavior.
2. It repurposes the "promote" flag for the homepage to control the visibility of  content in the language of the homepage across the site. Said otherwise content in Arabic is only displayed if the Arabic translation of the homepage is `published` and `promoted`.
3. It provides a route access handler to show a `404` when viewing a page in a language whose visibility is not enabled (access denied but 404 instead of 403 for better UX)
4. It provides some logic to deny access to entities if they don't have a translation in the current language or the global visibility of the language is not enabled (promote of the homepage).
5. Additionally and could have been in another PR, it allows admins to translate any entity.

### Testing

`Drush cim`, `drush cr` then as an anonymous visitor try to view pages in a language for which there is no translation or for which the homepage in the same language is not published and promoted. Then add a translation if none and promote/publish the homepage in that language. Do the same when logged in as normal admin user (not user 1) and check you have access to everything.

Also, as an anonymous user, on a Arabic page (and Arabic homepage published/promoted) with a sub-article not translated, check that the sub-article doesn't appear.