### PR TITLE
[GHO-19] Interactive content

### DIFF
--- a/config/core.entity_form_display.paragraph.interactive_content.default.yml
+++ b/config/core.entity_form_display.paragraph.interactive_content.default.yml
@@ -1,0 +1,60 @@
+uuid: 39428b73-cb1d-4f07-bb53-201cf088327c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.interactive_content.field_dataset
+    - field.field.paragraph.interactive_content.field_image
+    - field.field.paragraph.interactive_content.field_link
+    - field.field.paragraph.interactive_content.field_title
+    - field.field.paragraph.interactive_content.field_type
+    - paragraphs.paragraphs_type.interactive_content
+  module:
+    - gho_fields
+    - link
+    - media_library
+id: paragraph.interactive_content.default
+targetEntityType: paragraph
+bundle: interactive_content
+mode: default
+content:
+  field_dataset:
+    weight: 4
+    settings:
+      placeholder_url: 'Ex: https://humdata.org/dataset'
+      placeholder_title: 'Ex: Office for Coordination of Humanitarian Affairs'
+    third_party_settings: {  }
+    type: gho_dataset_link
+    region: content
+  field_image:
+    weight: 3
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    type: media_library_widget
+    region: content
+  field_link:
+    weight: 2
+    settings:
+      placeholder_url: 'Ex: https://datawrapper.de/content-page'
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_title:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_type:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.interactive_content.default.yml
+++ b/config/core.entity_view_display.paragraph.interactive_content.default.yml
@@ -1,0 +1,58 @@
+uuid: 4596d554-b9c0-4c8a-b7ef-88d459429ec2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.interactive_content.field_dataset
+    - field.field.paragraph.interactive_content.field_image
+    - field.field.paragraph.interactive_content.field_link
+    - field.field.paragraph.interactive_content.field_title
+    - field.field.paragraph.interactive_content.field_type
+    - paragraphs.paragraphs_type.interactive_content
+    - responsive_image.styles.interactive_content
+  module:
+    - gho_fields
+    - linked_responsive_image_media_formatter
+id: paragraph.interactive_content.default
+targetEntityType: paragraph
+bundle: interactive_content
+mode: default
+content:
+  field_dataset:
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: gho_dataset_link
+    region: content
+  field_image:
+    weight: 2
+    label: hidden
+    settings:
+      responsive_image_style: interactive_content
+      image_link: custom
+      image_link_url: '[paragraph:field_link]'
+      image_alt: custom
+      image_alt_value: '[paragraph:field_title]'
+      image_as_background: false
+    third_party_settings: {  }
+    type: linked_responsive_image_media_formatter
+    region: content
+  field_title:
+    weight: 1
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_type:
+    weight: 0
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  field_link: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -38,6 +38,7 @@ module:
   layout_discovery: 0
   layout_paragraphs: 0
   link: 0
+  linked_responsive_image_media_formatter: 0
   locale: 0
   maintenance200: 0
   media: 0

--- a/config/field.field.paragraph.interactive_content.field_dataset.yml
+++ b/config/field.field.paragraph.interactive_content.field_dataset.yml
@@ -1,0 +1,23 @@
+uuid: 381c607a-16a0-4ab9-8974-5448a63f219b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_dataset
+    - paragraphs.paragraphs_type.interactive_content
+  module:
+    - link
+id: paragraph.interactive_content.field_dataset
+field_name: field_dataset
+entity_type: paragraph
+bundle: interactive_content
+label: Source
+description: 'Source of the dataset used to generate the interactive content.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 2
+field_type: link

--- a/config/field.field.paragraph.interactive_content.field_image.yml
+++ b/config/field.field.paragraph.interactive_content.field_image.yml
@@ -1,0 +1,28 @@
+uuid: f2f99051-34fb-4f44-a66c-fcc6c9356de6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image
+    - media.type.image
+    - paragraphs.paragraphs_type.interactive_content
+id: paragraph.interactive_content.field_image
+field_name: field_image
+entity_type: paragraph
+bundle: interactive_content
+label: Thumbnail
+description: 'Image representing the content. When clicked it will redirect to the interactive content''s page.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.paragraph.interactive_content.field_link.yml
+++ b/config/field.field.paragraph.interactive_content.field_link.yml
@@ -1,0 +1,23 @@
+uuid: 41771d71-f2ea-4d98-9035-3655b90d9931
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.interactive_content
+  module:
+    - link
+id: paragraph.interactive_content.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: interactive_content
+label: Link
+description: 'Link to the interactive content.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/field.field.paragraph.interactive_content.field_title.yml
+++ b/config/field.field.paragraph.interactive_content.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 022f3321-bbb8-49de-95d3-6b354292c9e9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.interactive_content
+id: paragraph.interactive_content.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: interactive_content
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.interactive_content.field_type.yml
+++ b/config/field.field.paragraph.interactive_content.field_type.yml
@@ -1,0 +1,29 @@
+uuid: d12a2494-3954-4743-ac92-10d395b2e90b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_type
+    - paragraphs.paragraphs_type.interactive_content
+    - taxonomy.vocabulary.interactive_content_type
+id: paragraph.interactive_content.field_type
+field_name: field_type
+entity_type: paragraph
+bundle: interactive_content
+label: Type
+description: 'Type of the interactive content. Ex: Map.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      interactive_content_type: interactive_content_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.storage.paragraph.field_link.yml
+++ b/config/field.storage.paragraph.field_link.yml
@@ -1,0 +1,19 @@
+uuid: 2c191632-cc7c-4058-a851-19b9c3f5aa15
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_link
+field_name: field_link
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_type.yml
+++ b/config/field.storage.paragraph.field_type.yml
@@ -1,0 +1,20 @@
+uuid: 8c1d4ac1-0ae2-44f3-a2fc-5f9d562659ed
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - taxonomy
+id: paragraph.field_type
+field_name: field_type
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/image.style.full_width_100.yml
+++ b/config/image.style.full_width_100.yml
@@ -1,0 +1,16 @@
+uuid: b4009c69-bfa5-4a3c-b2be-81edd0de3eee
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_100
+label: 'Full width - 100%'
+effects:
+  23929a61-65a0-4ae8-a2e4-ad557d44465a:
+    uuid: 23929a61-65a0-4ae8-a2e4-ad557d44465a
+    id: image_scale
+    weight: 1
+    data:
+      width: 1140
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/image.style.full_width_133.yml
+++ b/config/image.style.full_width_133.yml
@@ -1,0 +1,16 @@
+uuid: 61509fca-02b4-4b97-b2d7-771579309da1
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_133
+label: 'Full width - 133%'
+effects:
+  59bd0266-3835-4750-81cc-1e5eee7252a6:
+    uuid: 59bd0266-3835-4750-81cc-1e5eee7252a6
+    id: image_scale
+    weight: 1
+    data:
+      width: 1520
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/image.style.full_width_180.yml
+++ b/config/image.style.full_width_180.yml
@@ -1,0 +1,16 @@
+uuid: 7a8f0d4f-b45b-4f68-a0c0-810b322869de
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_180
+label: 'Full width - 180%'
+effects:
+  b2129eec-9b4d-4a1d-958b-4a9e4142bd11:
+    uuid: b2129eec-9b4d-4a1d-958b-4a9e4142bd11
+    id: image_scale
+    weight: 1
+    data:
+      width: 2052
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/image.style.full_width_200.yml
+++ b/config/image.style.full_width_200.yml
@@ -1,0 +1,16 @@
+uuid: 800fd5ce-7279-4a05-9077-66bd995bf41e
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_200
+label: 'Full width - 200%'
+effects:
+  8c8cca48-ec77-485a-93d8-b2f20761c4ca:
+    uuid: 8c8cca48-ec77-485a-93d8-b2f20761c4ca
+    id: image_scale
+    weight: 1
+    data:
+      width: 2280
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/image.style.full_width_33.yml
+++ b/config/image.style.full_width_33.yml
@@ -1,0 +1,16 @@
+uuid: 55d7e503-6a67-4312-97a6-788f65d33ea8
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_33
+label: 'Full width - 33%'
+effects:
+  76bf95b4-78d4-4127-a542-9a0deb1db6fb:
+    uuid: 76bf95b4-78d4-4127-a542-9a0deb1db6fb
+    id: image_scale
+    weight: 1
+    data:
+      width: 380
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/image.style.full_width_50.yml
+++ b/config/image.style.full_width_50.yml
@@ -1,0 +1,16 @@
+uuid: 0fa5cd91-bd6f-4840-8c76-9a15615251ae
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_50
+label: 'Full width - 50%'
+effects:
+  f49ae510-9976-4cfb-bbc5-dd5918ff2650:
+    uuid: f49ae510-9976-4cfb-bbc5-dd5918ff2650
+    id: image_scale
+    weight: 1
+    data:
+      width: 570
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/image.style.full_width_66.yml
+++ b/config/image.style.full_width_66.yml
@@ -1,0 +1,16 @@
+uuid: 66f8ca65-04b8-4a19-a116-8b7fff87a633
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_66
+label: 'Full width - 66%'
+effects:
+  e1c6290c-6b59-4559-beac-66fb4c6c1005:
+    uuid: e1c6290c-6b59-4559-beac-66fb4c6c1005
+    id: image_scale
+    weight: 1
+    data:
+      width: 760
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/image.style.full_width_90.yml
+++ b/config/image.style.full_width_90.yml
@@ -1,0 +1,16 @@
+uuid: 5f4e1ebb-b585-4268-87e4-dfb3f02a4d1b
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_90
+label: 'Full width - 90%'
+effects:
+  97a2772a-b643-4132-acdb-92f03300cf94:
+    uuid: 97a2772a-b643-4132-acdb-92f03300cf94
+    id: image_scale
+    weight: 1
+    data:
+      width: 1026
+      height: null
+      upscale: false
+pipeline: __default__

--- a/config/language.content_settings.taxonomy_term.interactive_content_type.yml
+++ b/config/language.content_settings.taxonomy_term.interactive_content_type.yml
@@ -1,0 +1,16 @@
+uuid: a9977d41-d4f1-4e2b-8421-2af3097d4b5f
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.interactive_content_type
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.interactive_content_type
+target_entity_type_id: taxonomy_term
+target_bundle: interactive_content_type
+default_langcode: site_default
+language_alterable: false

--- a/config/paragraphs.paragraphs_type.interactive_content.yml
+++ b/config/paragraphs.paragraphs_type.interactive_content.yml
@@ -1,0 +1,10 @@
+uuid: 4a2a8d48-022d-4e1e-b656-42e5ef1738bd
+langcode: en
+status: true
+dependencies: {  }
+id: interactive_content
+label: 'Interactive content'
+icon_uuid: null
+icon_default: null
+description: 'Interactive content like an infographic, a map or a table.'
+behavior_plugins: {  }

--- a/config/responsive_image.styles.interactive_content.yml
+++ b/config/responsive_image.styles.interactive_content.yml
@@ -1,0 +1,59 @@
+uuid: 69d5eaa9-1186-459d-85f2-2c7e3adc3fd1
+langcode: en
+status: true
+dependencies:
+  config:
+    - image.style.full_width_100
+    - image.style.full_width_133
+    - image.style.full_width_180
+    - image.style.full_width_200
+    - image.style.full_width_50
+    - image.style.full_width_66
+    - image.style.full_width_90
+  theme:
+    - common_design
+id: interactive_content
+label: 'Interactive content'
+image_style_mappings:
+  -
+    breakpoint_id: common_design.lg
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: full_width_100
+  -
+    breakpoint_id: common_design.lg
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: full_width_200
+  -
+    breakpoint_id: common_design.md
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: full_width_90
+  -
+    breakpoint_id: common_design.md
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: full_width_180
+  -
+    breakpoint_id: common_design.sm
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: full_width_66
+  -
+    breakpoint_id: common_design.sm
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: full_width_133
+  -
+    breakpoint_id: common_design.xs
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: full_width_50
+  -
+    breakpoint_id: common_design.xs
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: full_width_100
+breakpoint_group: common_design
+fallback_image_style: full_width_50

--- a/config/taxonomy.vocabulary.interactive_content_type.yml
+++ b/config/taxonomy.vocabulary.interactive_content_type.yml
@@ -1,0 +1,8 @@
+uuid: 67e0b1fc-38fe-4ebd-9dfb-dc7438815156
+langcode: en
+status: true
+dependencies: {  }
+name: 'Interactive content type'
+vid: interactive_content_type
+description: 'Type of an interactive content (ex: infographic)'
+weight: 0

--- a/html/modules/custom/gho_general/gho_general.links.action.yml
+++ b/html/modules/custom/gho_general/gho_general.links.action.yml
@@ -53,6 +53,18 @@ gho_general.add_story_type:
   # https://www.drupal.org/project/drupal/issues/1344902 is solved.
   class: \Drupal\menu_ui\Plugin\Menu\LocalAction\MenuLinkAdd
 
+gho_general.add_interactive_content_type:
+  title: 'Add interactive content type'
+  route_name: entity.taxonomy_term.add_form
+  route_parameters:
+    taxonomy_vocabulary: interactive_content_type
+  appears_on:
+    - view.content_taxonomy_terms.page_admin_content_terms
+  # Temporary solution to ensure redirection to the origin page until
+  # https://www.drupal.org/project/drupal/issues/1344902 is solved.
+  class: \Drupal\menu_ui\Plugin\Menu\LocalAction\MenuLinkAdd
+
+
 gho_general.add_document:
   title: 'Add document'
   route_name: entity.media.add_form

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -114,3 +114,8 @@ gho-embed:
    css:
      theme:
        components/gho-embed/gho-embed.css: {}
+
+gho-interactive-content:
+   css:
+     theme:
+       components/gho-interactive-content/gho-interactive-content.css: {}

--- a/html/themes/custom/common_design_subtheme/components/gho-interactive-content/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-interactive-content/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Interactive Content Component
+============================================================
+
+Styling of interactive content (ex: map, infographic etc.).

--- a/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.css
@@ -1,0 +1,6 @@
+.gho-interactive-content .field--name-field-image {
+  max-width: 904px;
+}
+.gho-interactive-content .gho-dataset-link {
+  margin-top: 1rem;
+}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--interactive-content.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--interactive-content.html.twig
@@ -1,0 +1,67 @@
+{#
+/**
+ * @file
+ * Theme implementation for a interactive content paragraph.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.a
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-interactive-content') }}
+{{ attach_library('common_design_subtheme/gho-aside') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-interactive-content',
+    'gho-aside',
+    'gho-aside--dark',
+    'gho-bleed--background-only',
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      <header class="gho-interactive-content__header">
+        <span class="gho-aside__pre-title">{{- content.field_type -}}</span>
+        <h2 class="gho-aside__title">{{- content.field_title -}}</h2>
+      </header>
+      {{ content|without(['field_type', 'field_title']) }}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
Tickets: GHO-19, GHO-21

This adds a paragraph type for interactive content with a type (pre-title), title, image (screenshot of the interactive content), link (to the interactive content) and dataset source.



This quite similar to the "Stories" except it's a paragraph type not a content type because we don't need to have individually accessible pages for those as they embed/link to external content.

There is new "interactive content type" vocabulary to avoid mixing the terms with the story types.

<img width="425" alt="Screen Shot 2020-11-10 at 20 22 11" src="https://user-images.githubusercontent.com/696348/98668045-a37ce200-2392-11eb-889a-2164a26a6c32.png">

This uses the `linked_responsive_image_media_formatter` custom module to generate the clickable image.

The  styling re-uses the story  type one with a large image (904px).

<img width="750" alt="Screen Shot 2020-11-10 at 19 41 20" src="https://user-images.githubusercontent.com/696348/98668143-cf986300-2392-11eb-8e74-ffd15188745d.png">

### Testing

`drush cim`, `drush cr` and add some interactive content type terms and then a interactive content paragraph to an article.
