### PR TITLE
[GHO-34] Article caption

### DIFF
--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
+    - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_report_link
@@ -13,6 +14,7 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
+    - double_field
     - inline_entity_form
     - layout_paragraphs
     - link
@@ -47,6 +49,33 @@ content:
       allow_duplicate: false
     third_party_settings: {  }
     region: content
+  field_caption:
+    weight: 6
+    settings:
+      first:
+        type: textfield
+        label_display: block
+        size: 60
+        placeholder: 'Ex: Mbuji-Mayi, RDC'
+        label: Ok
+        cols: 10
+        rows: 5
+        prefix: ''
+        suffix: ''
+      second:
+        type: textarea
+        label_display: block
+        size: 10
+        placeholder: ''
+        label: Ok
+        cols: 10
+        rows: 5
+        prefix: ''
+        suffix: ''
+      inline: false
+    third_party_settings: {  }
+    type: double_field
+    region: content
   field_hero_image:
     type: media_library_widget
     weight: 5
@@ -55,7 +84,7 @@ content:
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    weight: 8
+    weight: 9
     settings:
       preview_view_mode: default
       nesting_depth: 4
@@ -78,7 +107,7 @@ content:
     type: options_select
     region: content
   field_summary:
-    weight: 7
+    weight: 8
     settings:
       rows: 5
       placeholder: ''
@@ -87,14 +116,14 @@ content:
     region: content
   field_thumbnail_image:
     type: media_library_widget
-    weight: 6
+    weight: 7
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   path:
     type: path
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -102,7 +131,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 11
     region: content
     third_party_settings: {  }
   title:

--- a/config/core.entity_form_display.node.article.home_page.yml
+++ b/config/core.entity_form_display.node.article.home_page.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_form_mode.node.home_page
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
+    - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_report_link
@@ -87,6 +88,7 @@ hidden:
   created: true
   field_appeals: true
   field_author: true
+  field_caption: true
   field_thumbnail_image: true
   langcode: true
   path: true

--- a/config/core.entity_view_display.node.article.default.yml
+++ b/config/core.entity_view_display.node.article.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
+    - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_report_link
@@ -14,6 +15,7 @@ dependencies:
     - node.type.article
   module:
     - entity_reference_revisions
+    - gho_fields
     - link
     - user
 id: node.article.default
@@ -32,12 +34,19 @@ content:
     region: content
   field_author:
     type: entity_reference_entity_view
-    weight: 4
+    weight: 5
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
+    region: content
+  field_caption:
+    weight: 4
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: gho_caption
     region: content
   field_hero_image:
     type: entity_reference_entity_view
@@ -49,7 +58,7 @@ content:
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    weight: 5
+    weight: 6
     label: hidden
     settings:
       view_mode: default
@@ -59,7 +68,7 @@ content:
     region: content
   field_report_link:
     type: link
-    weight: 6
+    weight: 7
     region: content
     label: hidden
     settings:

--- a/config/core.entity_view_display.node.article.home_page.yml
+++ b/config/core.entity_view_display.node.article.home_page.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.home_page
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
+    - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_report_link
@@ -73,6 +74,7 @@ content:
 hidden:
   field_appeals: true
   field_author: true
+  field_caption: true
   field_section: true
   field_thumbnail_image: true
   langcode: true

--- a/config/core.entity_view_display.node.article.related_article.yml
+++ b/config/core.entity_view_display.node.article.related_article.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.related_article
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
+    - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_report_link
@@ -45,6 +46,7 @@ content:
 hidden:
   field_appeals: true
   field_author: true
+  field_caption: true
   field_hero_image: true
   field_paragraphs: true
   field_report_link: true

--- a/config/core.entity_view_display.node.article.sub_article.yml
+++ b/config/core.entity_view_display.node.article.sub_article.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.sub_article
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
+    - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_report_link
@@ -14,6 +15,7 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
+    - gho_fields
     - layout_builder
     - layout_paragraphs
     - user
@@ -37,13 +39,20 @@ content:
     region: content
   field_author:
     type: entity_reference_entity_view
-    weight: 2
+    weight: 3
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
     region: content
+  field_caption:
+    type: gho_caption
+    weight: 2
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
   field_hero_image:
     type: entity_reference_entity_view
     weight: 0
@@ -54,7 +63,7 @@ content:
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       view_mode: default

--- a/config/core.entity_view_display.node.article.teaser.yml
+++ b/config/core.entity_view_display.node.article.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
+    - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_report_link
@@ -40,6 +41,7 @@ content:
 hidden:
   field_appeals: true
   field_author: true
+  field_caption: true
   field_hero_image: true
   field_paragraphs: true
   field_report_link: true

--- a/config/field.field.node.article.field_caption.yml
+++ b/config/field.field.node.article.field_caption.yml
@@ -1,0 +1,39 @@
+uuid: b94a02a0-4a26-43f6-8d30-cc931f830b38
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_caption
+    - node.type.article
+  module:
+    - double_field
+id: node.article.field_caption
+field_name: field_caption
+entity_type: node
+bundle: article
+label: Caption
+description: 'Caption that will be displayed below the title. It should contain a <strong>location</strong> in the form <em>Location, Country</em>. Ex: <em>Mbuji-Mayi, RDC</em> and a <strong>text</strong>. Credits for the hero image will be automatically added to the end when displayed.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  first:
+    label: Location
+    required: true
+    list: false
+    allowed_values: {  }
+    max: null
+    min: null
+    on_label: 'On'
+    off_label: 'Off'
+  second:
+    label: Text
+    required: true
+    list: false
+    allowed_values: {  }
+    max: null
+    min: null
+    on_label: 'On'
+    off_label: 'Off'
+field_type: double_field

--- a/config/field.storage.node.field_caption.yml
+++ b/config/field.storage.node.field_caption.yml
@@ -1,0 +1,32 @@
+uuid: 0730090d-ba8b-4315-8de4-5a849696894a
+langcode: en
+status: true
+dependencies:
+  module:
+    - double_field
+    - node
+id: node.field_caption
+field_name: field_caption
+entity_type: node
+type: double_field
+settings:
+  storage:
+    first:
+      type: string
+      maxlength: 255
+      precision: 10
+      scale: 2
+      datetime_type: datetime
+    second:
+      type: text
+      maxlength: 255
+      precision: 10
+      scale: 2
+      datetime_type: datetime
+module: double_field
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/html/modules/custom/gho_fields/config/schema/gho_fields.schema.yml
+++ b/html/modules/custom/gho_fields/config/schema/gho_fields.schema.yml
@@ -1,4 +1,9 @@
 # Formatters.
+field.formatter.settings.gho_caption:
+  type: mapping
+  label: 'GHO caption formatter settings'
+  mapping:
+    # No settings.
 field.formatter.settings.gho_dataset_link:
   type: mapping
   label: 'GHO dataset link formatter settings'

--- a/html/modules/custom/gho_fields/gho_fields.module
+++ b/html/modules/custom/gho_fields/gho_fields.module
@@ -33,6 +33,13 @@ function gho_fields_theme() {
         'list' => NULL,
       ],
     ],
+    'gho_caption_formatter' => [
+      'variables' => [
+        'location' => NULL,
+        'caption' => NULL,
+        'credits' => NULL,
+      ],
+    ],
   ];
 }
 

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoCaptionFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoCaptionFormatter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\gho_fields\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * Plugin implementations for 'gho_caption' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "gho_caption",
+ *   label = @Translation("GHO caption formatter"),
+ *   field_types = {
+ *     "double_field"
+ *   }
+ * )
+ */
+class GhoCaptionFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+
+    foreach ($items as $delta => $item) {
+      $element[$delta] = [
+        '#location' => $item->first,
+        '#caption' => $item->second,
+        // This is needs to be set in a hook_preprocess_gho_caption_formatter().
+        '#credits' => NULL,
+        '#theme' => 'gho_caption_formatter',
+      ];
+    }
+
+    return $element;
+  }
+
+}

--- a/html/modules/custom/gho_fields/templates/gho-caption-formatter.html.twig
+++ b/html/modules/custom/gho_fields/templates/gho-caption-formatter.html.twig
@@ -1,0 +1,11 @@
+<div class="gho-caption">
+  <p class="gho-caption__location location">{{ location }}</p>
+  {% spaceless %}
+  <p class="gho-caption__caption caption">
+    {{ caption }}
+    {% if credits %}
+      <span class="gho-caption__credits credits">{{ credits }}</span>
+    {% endif %}
+  </p>
+  {% endspaceless %}
+</div>

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -177,6 +177,12 @@ function common_design_subtheme_preprocess_node__article(&$variables) {
     $node_id = $variables['node']->id();
     $node_uri = 'entity:node/' . $node_id;
 
+    // Copy the hero image credits to the end of the caption field.
+    if (isset($variables['content']['field_hero_image'][0]['#media'])) {
+      $credits = $variables['content']['field_hero_image'][0]['#media']->field_credits->value;
+      $variables['content']['field_caption'][0]['#credits'] = ['#markup' => $credits];
+    }
+
     // Load the menu link associated with the node.
     $storage = \Drupal::service('entity_type.manager')->getStorage('menu_link_content');
     $links = $storage->loadByProperties(['link__uri' => $node_uri]);

--- a/html/themes/custom/common_design_subtheme/components/gho-article/gho-article.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article/gho-article.css
@@ -47,3 +47,24 @@
 .gho-article .gho-article__local_tasks {
   margin-top: 2rem;
 }
+
+/* @todo Move that in a `gho-caption` component? */
+/* Bonus: the styles below apply to the sub-articles as well. */
+.gho-article .gho-caption {
+  max-width: var(--reading-width);
+  /* @todo adjust margin-top after reviewing title's margins. */
+  margin: 2rem 0;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: #6d6d6d;
+}
+.gho-article .gho-caption__location {
+  margin-bottom: 0;
+  font-weight: bold;
+}
+.gho-article .gho-caption__caption {
+  margin-top: 0;
+}
+.gho-article .gho-caption__credits {
+  font-style: italic;
+}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-caption--article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-caption--article.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}


### PR DESCRIPTION
Ticket: GHO-9, GHO-34

This adds the article caption via a double field on the node and using the credits from the hero image.

<img width="596" alt="Screen Shot 2020-11-12 at 22 44 46" src="https://user-images.githubusercontent.com/696348/98947551-b7624880-2538-11eb-9bb2-f3cf85c0e27e.png">

<img width="948" alt="Screen Shot 2020-11-12 at 22 36 04" src="https://user-images.githubusercontent.com/696348/98946644-7c134a00-2537-11eb-850e-50081b097048.png">

**Note** The margin between the title and the caption need to be adjusted as well as lots of other places so leaving that for another PR.

## Testing

`drush cim`, `drush cr` and add a location/caption to an article.

Note: there may be a classic issue of the chicken and egg like it happened in other PRs, when running the drush commands. Another run of those 2 commands should fix it.