### PR TITLE
[GHO-101] Allow 2 columns layout and limit width

### DIFF
--- a/config/core.entity_view_display.node.article.default.yml
+++ b/config/core.entity_view_display.node.article.default.yml
@@ -13,7 +13,7 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
-    - entity_reference_revisions
+    - layout_paragraphs
     - link
     - user
 id: node.article.default
@@ -55,7 +55,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    type: entity_reference_revisions_entity_view
+    type: layout_paragraphs
     region: content
   field_report_link:
     type: link

--- a/config/core.entity_view_display.node.article.home_page.yml
+++ b/config/core.entity_view_display.node.article.home_page.yml
@@ -14,8 +14,8 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
-    - entity_reference_revisions
     - layout_builder
+    - layout_paragraphs
     - link
     - text
     - user
@@ -38,7 +38,7 @@ content:
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    type: entity_reference_revisions_entity_view
+    type: layout_paragraphs
     weight: 4
     region: content
     label: hidden

--- a/config/paragraphs.paragraphs_type.layout.yml
+++ b/config/paragraphs.paragraphs_type.layout.yml
@@ -13,9 +13,4 @@ behavior_plugins:
   layout_paragraphs:
     enabled: true
     available_layouts:
-      layout_onecol: 'One column'
       layout_twocol_section: 'Two column'
-      layout_threecol_section: 'Three column'
-      layout_fourcol_section: 'Four column'
-      layout_image_grid_five_columns: 'Image grid (up to 5 columns)'
-      layout_image_grid_four_columns: 'Image grid (up to 4 columns)'

--- a/html/themes/custom/common_design_subtheme/layouts/twocol_section/twocol_section.css
+++ b/html/themes/custom/common_design_subtheme/layouts/twocol_section/twocol_section.css
@@ -8,6 +8,7 @@
 .layout--twocol-section {
   /* Compensate for the padding of the regions. */
   margin: -1rem;
+  max-width: var(--reading-width);
 }
 
 .layout--twocol-section:after {


### PR DESCRIPTION
Ticket: GHO-101

This brings some simple changes to allow the use of the 2 columns layout. That doesn't change anything for the existing content but in case it is decided to go with the 2 columns option then it's "ready".

I also removed the other layouts (3, 4 columns, grid) to avoid giving "ideas".

`drush cim`, `drush cr`