### PR TITLE
[GHO-98] Add highlight style for paragraphs in ckeditor

### DIFF
--- a/config/editor.editor.limited_html.yml
+++ b/config/editor.editor.limited_html.yml
@@ -17,6 +17,7 @@ settings:
           items:
             - Bold
             - Italic
+            - Styles
         -
           name: Links
           items:
@@ -42,9 +43,11 @@ settings:
             - Source
   plugins:
     stylescombo:
-      styles: ''
+      styles: p.highlight|Highlight
     language:
       language_list: un
+    customconfig:
+      ckeditor_custom_config: ''
 image_upload:
   status: false
   scheme: private

--- a/config/filter.format.limited_html.yml
+++ b/config/filter.format.limited_html.yml
@@ -14,7 +14,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a href target> <em> <strong> <cite> <blockquote cite> <ul type> <ol start type 1 a i''''> <li> <dl> <dt> <dd> <p> <br>'
+      allowed_html: '<a href target> <em> <strong> <cite> <blockquote cite> <ul type> <ol start type 1 a i''''> <li> <dl> <dt> <dd> <br> <p class="highlight">'
       filter_html_help: false
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
@@ -48,3 +48,4 @@ libraries-override:
 # Use the common_design_admin_subtheme styles inside the editor.
 ckeditor_stylesheets:
   - css/ckeditor/footnotes.css
+  - css/ckeditor/styles.css

--- a/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
@@ -1,3 +1,8 @@
 .paragraph--type--text {
-  max-width: 720px; /* reading-width */
+  max-width: var(--reading-width);
+}
+.paragraph--type--text p.highlight {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 2.25rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
@@ -1,7 +1,7 @@
 .paragraph--type--text {
   max-width: var(--reading-width);
 }
-.paragraph--type--text p.highlight {
+.field--name-field-text .highlight {
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 2.25rem;

--- a/html/themes/custom/common_design_subtheme/css/ckeditor/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/ckeditor/styles.css
@@ -1,0 +1,5 @@
+p.highlight {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 2.25rem;
+}


### PR DESCRIPTION
Ticket: GHO-98

Add a "highlight" for paragraph (`<p>`) in ckeditor for `text` paragraph types to allow the following:

<img width="476" alt="Screen Shot 2020-11-13 at 13 08 37" src="https://user-images.githubusercontent.com/696348/99027773-5e82c680-25b1-11eb-8a68-b4f7b06abe88.png">


`drush cim`, `drush cr`, edit a `text` paragraph, select a paragraph, click "styles" dropdown and select "Highlight".