### PR TITLE
[GHO-96] Page 404

### DIFF
--- a/html/modules/custom/gho_access/gho_access.module
+++ b/html/modules/custom/gho_access/gho_access.module
@@ -9,7 +9,6 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\block\BlockInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\media\MediaInterface;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
@@ -67,9 +66,12 @@ function gho_access_media_access(MediaInterface $media, $operation, AccountInter
 function gho_access_taxonomy_term_access(TermInterface $term, $operation, AccountInterface $account) {
   switch ($operation) {
     case 'view':
+      // Skip the needs and requirements because they are not translatable
+      // and the figures are automatically translated by the GhoNumberFormatter
+      // provided in gho_fields.
       if ($term->bundle() !== 'needs_and_requirements') {
         // Check the access to the translation.
-        return gho_access_check_language_access($term, $account);
+        return gho_access_check_language_access($account, $term->language()->getId());
       }
   }
   // No opinion, let other modules handle the permissions.
@@ -99,7 +101,7 @@ function gho_access_form_user_form_alter(&$form, FormStateInterface $form_state,
  */
 function gho_access_block_access(BlockInterface $block, $operation, AccountInterface $account) {
   if ($operation === 'view' && $block->id() === 'mainnavigation') {
-    return gho_access_check_language_access(NULL, $account);
+    return gho_access_check_language_access($account);
   }
 
   // No opinion, let other modules handle the permissions.
@@ -129,7 +131,7 @@ function gho_access_check_node_language_access(NodeInterface $node, AccountInter
     return AccessResult::neutral();
   }
 
-  return gho_access_check_language_access($node, $account);
+  return gho_access_check_language_access($account, $node->language()->getId());
 }
 
 /**
@@ -154,16 +156,16 @@ function gho_access_check_media_language_access(MediaInterface $media, AccountIn
     $skip_homepage_check = $node->field_hero_image->target_id == $media->id();
   }
 
-  return gho_access_check_language_access($media, $account, $skip_homepage_check);
+  return gho_access_check_language_access($account, $media->language()->getId(), $skip_homepage_check);
 }
 
 /**
  * Check if an account is allowed to view content in the current language.
  *
- * @param \Drupal\Core\Entity\EntityInterface|null $entity
- *   Optional entity to check access for.
  * @param \Drupal\Core\Session\AccountInterface $account
  *   User account.
+ * @param string|null $entity_langcode
+ *   Optional entity language code to compare with the current language.
  * @param bool $skip_homepage_check
  *   Skip the homepage check.
  *
@@ -171,7 +173,7 @@ function gho_access_check_media_language_access(MediaInterface $media, AccountIn
  *   Access result: either neutral if the account is allowed to access the
  *   content or forbidden otherwise.
  */
-function gho_access_check_language_access(?EntityInterface $entity, AccountInterface $account, $skip_homepage_check = FALSE) {
+function gho_access_check_language_access(AccountInterface $account, $entity_langcode = NULL, $skip_homepage_check = FALSE) {
   // Get the current language.
   $langcode = \Drupal::service('language_manager')->getCurrentLanguage()->getId();
 
@@ -183,7 +185,7 @@ function gho_access_check_language_access(?EntityInterface $entity, AccountInter
   }
   // If there is a mismatch between the current language and the entity language
   // we deny access.
-  elseif (isset($entity) && $entity->language()->getId() !== $langcode) {
+  elseif (isset($entity_langcode) && $entity_langcode !== $langcode) {
     $access = AccessResult::forbidden();
   }
   // If we don't need to check the homepage then simply let the other modules

--- a/html/modules/custom/gho_access/src/Access/GhoLanguageVisibilityAccessCheck.php
+++ b/html/modules/custom/gho_access/src/Access/GhoLanguageVisibilityAccessCheck.php
@@ -52,7 +52,7 @@ class GhoLanguageVisibilityAccessCheck implements AccessInterface {
 
     // Check the node access for the current language. Skip the check on the
     // homepage if the current page is the homepage.
-    $access = gho_access_check_language_access($node, $account, $nid == 1);
+    $access = gho_access_check_language_access($account, $node->language()->getId(), $nid == 1);
 
     // Ensure the cache gets cleared when the permissions or the node change.
     $access->cachePerPermissions()->addCacheableDependency($node);

--- a/html/modules/custom/gho_access/src/GhoAccessServiceProvider.php
+++ b/html/modules/custom/gho_access/src/GhoAccessServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\gho_access;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Overrides the default tree manipulators handler service.
+ */
+class GhoAccessServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    $definition = $container->getDefinition('menu.default_tree_manipulators');
+    $definition->setClass('Drupal\gho_access\Menu\GhoMenuLinkTreeManipulators')
+      ->addArgument(new Reference('language_manager'));
+  }
+
+}

--- a/html/modules/custom/gho_access/src/Menu/GhoMenuLinkTreeManipulators.php
+++ b/html/modules/custom/gho_access/src/Menu/GhoMenuLinkTreeManipulators.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\gho_access\Menu;
+
+use Drupal\Core\Access\AccessManagerInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Menu\DefaultMenuLinkTreeManipulators;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\node\NodeInterface;
+
+/**
+ * Provides a couple of menu link tree manipulators.
+ *
+ * Overrides \Drupal\Core\Menu\DefaultMenuLinkTreeManipulators.
+ *
+ * Adds special check for node access.
+ *
+ * This class provides menu link tree manipulators to:
+ * - perform render cached menu-optimized access checking
+ * - optimized node access checking
+ * - generate a unique index for the elements in a tree and sorting by it
+ * - flatten a tree (i.e. a 1-dimensional tree)
+ */
+class GhoMenuLinkTreeManipulators extends DefaultMenuLinkTreeManipulators {
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs a \Drupal\Core\Menu\DefaultMenuLinkTreeManipulators object.
+   *
+   * @param \Drupal\Core\Access\AccessManagerInterface $access_manager
+   *   The access manager.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The current user.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   */
+  public function __construct(AccessManagerInterface $access_manager, AccountInterface $account, EntityTypeManagerInterface $entity_type_manager, LanguageManagerInterface $language_manager) {
+    $this->accessManager = $access_manager;
+    $this->account = $account;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function checkNodeAccess(array $tree) {
+    // Nothing more todo that the default access check if the user
+    // is allowed to access content in any language.
+    if ($this->account->hasPermission('view untranslated content')) {
+      return parent::checkNodeAccess($tree);
+    }
+
+    $node_links = [];
+    // Calling this function denies access to all the links. Access is granted
+    // by the code below for the node links that match the criteria.
+    // @see \Drupal\Core\Menu\DefaultMenuLinkTreeManipulators::checkNodeAccess()
+    $this->collectNodeLinks($tree, $node_links);
+    if ($node_links) {
+      // Exit early if the visibility for the language is not enabled.
+      $langcode = $this->languageManager->getCurrentLanguage()->getId();
+      if (!gho_access_check_language_visibility($langcode)) {
+        return $tree;
+      }
+
+      // The code below is the same as the parent class except for the condition
+      // on the language code below.
+      $nids = array_keys($node_links);
+
+      $query = $this->entityTypeManager->getStorage('node')->getQuery();
+      $query->condition('nid', $nids, 'IN');
+
+      // Allows admins to view all nodes, by both disabling node_access
+      // query rewrite as well as not checking for the node status. The
+      // 'view own unpublished nodes' permission is ignored to not require cache
+      // entries per user.
+      $access_result = AccessResult::allowed()->cachePerPermissions();
+      if ($this->account->hasPermission('bypass node access')) {
+        $query->accessCheck(FALSE);
+      }
+      else {
+        $access_result->addCacheContexts(['user.node_grants:view']);
+        $query->condition('status', NodeInterface::PUBLISHED);
+        // This is to prevent language mismatch.
+        $query->condition('langcode', $langcode, 'IN');
+      }
+
+      $nids = $query->execute();
+      foreach ($nids as $nid) {
+        foreach ($node_links[$nid] as $key => $link) {
+          $node_links[$nid][$key]->access = $access_result;
+        }
+      }
+    }
+
+    return $tree;
+  }
+
+}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -124,3 +124,8 @@ gho-interactive-content:
   css:
     theme:
       components/gho-interactive-content/gho-interactive-content.css: {}
+
+gho-page-404:
+  css:
+    theme:
+      components/gho-page-404/gho-page-404.css: {}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -7,7 +7,21 @@
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\node\NodeInterface;
+use Drupal\Core\Url;
 use Drupal\gho_fields\Plugin\Field\FieldFormatter\GhoRelatedArticlesFormatter;
+
+/**
+ * Implements hook_menu().
+ */
+function common_design_subtheme_theme() {
+  return [
+    'menu__page_not_found' => [
+      'base hook' => 'menu',
+    ],
+  ];
+}
 
 /**
  * Get the list of components to attach to formatted text fields.
@@ -237,6 +251,113 @@ function common_design_subtheme_preprocess_page(&$variables) {
       unset($variables['page']['content']['common_design_subtheme_local_tasks']);
     }
   }
+}
+
+/**
+ * Implements hook_preprocess_page__404().
+ */
+function common_design_subtheme_preprocess_page__404(&$variables) {
+  // Generate the message to display before the menu.
+  $notfound = t('The page @path was not found.', [
+    '@path' => \Drupal::request()->getPathInfo() ?? '/',
+  ]);
+  $message = [
+    '<strong>' . $notfound . '</strong>',
+    t('Sorry for any inconvenience.'),
+    t('Here are some useful pages to help you get back on track:'),
+  ];
+
+  // Set the page content.
+  $variables['page']['content']['system_main'] = [
+    '#type' => 'container',
+    '#attributes' => [
+      'class' => ['gho-page-404'],
+    ],
+    '#attached' => [
+      'library' => ['common_design_subtheme/gho-page-404'],
+    ],
+    'message' => ['#markup' => '<p>' . implode('</p><p>', $message) . '</p>'],
+    'navigation' => common_design_subtheme_get_navigation_tree(),
+  ];
+}
+
+/**
+ * Get the navigation tree for the 404 page.
+ *
+ * @return array
+ *   Render array with either the main navigation tree or with a link to the
+ *   homepage in English if there is none in the current language.
+ */
+function common_design_subtheme_get_navigation_tree() {
+  $language_manager = \Drupal::service('language_manager');
+  $langcode = $language_manager->getCurrentLanguage()->getId();
+
+  // Check if the homepage in the given language exists.
+  $storage = \Drupal::service('entity_type.manager')->getStorage('node');
+  $ids = $storage->getQuery()
+    ->condition('nid', 1)
+    ->condition('langcode', $langcode)
+    ->condition('status', NodeInterface::PUBLISHED)
+    ->execute();
+
+  // Show a link to the homepage in English if there is no homepage in the
+  // current language.
+  if (empty($ids)) {
+    $default_language = $language_manager->getDefaultLanguage();
+    return [
+      '#theme' => 'menu__page_not_found',
+      '#items' => [
+        'home page' => [
+          'title' => t('Home page in @language', [
+            '@language' => $default_language->getName(),
+          ]),
+          'url' => new Url('<front>', [], [
+            'language' => $default_language,
+          ]),
+        ],
+      ],
+    ];
+  }
+
+  $menu_tree = \Drupal::service('menu.link_tree');
+
+  // Parameter to load the menu children of the given menu.
+  $parameters = new MenuTreeParameters();
+  $parameters->setMaxdepth(2);
+  $parameters->excludeRoot();
+
+  // Load tree.
+  $tree = $menu_tree->load('main', $parameters);
+
+  // Check the access to the nodes in the menu and ensure they are sorted.
+  $manipulators = [
+    ['callable' => 'menu.default_tree_manipulators:checkNodeAccess'],
+    ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+    ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+  ];
+
+  // Tree is an associated array with a key for the parent menu entry
+  // and a \Drupal\Core\Menu\MenuLinkTreeElement[] as value.
+  $tree = $menu_tree->transform($tree, $manipulators);
+
+  // Get the render for the tree and use the theme for the page not found.
+  $build = $menu_tree->build($tree);
+  $build['#theme'] = 'menu__page_not_found';
+
+  // Remove the menu items without children.
+  $items = array_filter($build['#items'], function ($item) {
+    return !empty($item['below']);
+  });
+
+  // Add the homepage as first link.
+  $build['#items'] = [
+    'home page' => [
+      'title' => t('Home page'),
+      'url' => new Url('<front>'),
+    ],
+  ] + $items;
+
+  return $build;
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/gho-page-404/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-page-404/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Page 404 Component
+=================================================
+
+Styling for the 404 page.

--- a/html/themes/custom/common_design_subtheme/components/gho-page-404/gho-page-404.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-page-404/gho-page-404.css
@@ -1,0 +1,6 @@
+.gho-page-404 .menu-level-0 {
+  margin-left: 0;
+}
+.gho-page-404 .menu-item {
+  margin-top: 1rem;
+}

--- a/html/themes/custom/common_design_subtheme/templates/menu--page-not-found.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/menu--page-not-found.html.twig
@@ -1,0 +1,47 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link url, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see http://twig.sensiolabs.org/doc/tags/macro.html
+#}
+{{ menus.menu_links(items, attributes, 0) }}
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    <ul{{ attributes.addClass('menu').addClass('menu-level-' ~ menu_level) }}>
+    {% for item in items %}
+      <li{{ item.attributes.addClass('menu-item') }}>
+        {% if item.url %}
+          {{ link(item.title, item.url) }}
+        {% else %}
+          {{ item.title }}
+        {% endif %}
+        {% if item.below %}
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
Ticket: GHO-96

This customizes a bit the 404 page with links to the homepage and main articles. This based on the ReliefWeb 404: https://reliefweb.int/blabla

This PR contains also some modifications to the access checks to handle menus.

<img width="1255" alt="Screen Shot 2020-11-13 at 18 14 45" src="https://user-images.githubusercontent.com/696348/99053215-407e8b80-25dc-11eb-9c4c-a603dff4c6ca.png">

If the homepage in the requested language doesn't exist, it shows a link to the English page:

<img width="540" alt="Screen Shot 2020-11-13 at 18 15 30" src="https://user-images.githubusercontent.com/696348/99053519-5be99680-25dc-11eb-979f-fb05aed47fdf.png">

## String to translate

1. `The page @path was not found.`
2. `Sorry for any inconvenience.`
3. `Here are some useful pages to help you get back on track:`
4. `Home page in @language`

## Testing

`drush cim` and `drush cr` and just visit a page that doesn't exist. Ex: https://gho.test/blabla and https://gho.test/fr/blabla
 