### PR TITLE
GHO-98: undo css mods

### DIFF
--- a/html/themes/custom/common_design_admin_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_admin_subtheme/css/styles.css
@@ -28,15 +28,15 @@
   max-width: 720px;
 }
 
-/* this is inside other stuff like Story */
-.field--type-text-long {
-  max-width: 720px;
-}
-
-.field--name-field-text .highlight {
+.paragraph--type--text .highlight {
   font-size: 1.25rem;
   font-weight: 700;
   line-height: 2.25rem;
+}
+
+/* this is inside other stuff like Story */
+.field--type-text-long {
+  max-width: 720px;
 }
 
 /*------------------------------------------------------------------------------

--- a/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
@@ -1,7 +1,7 @@
 .paragraph--type--text {
   max-width: var(--reading-width);
 }
-.field--name-field-text .highlight {
+.paragraph--type--text p.highlight {
   font-size: 1.5rem;
   font-weight: 700;
   line-height: 2.25rem;


### PR DESCRIPTION
# GHO-98

I made some assumptions in #94  and #98 which need to be reversed. Here's how it works now:

### Goal of GHO-98: allow "highlight" paragraph

<img width="906" alt="Screen Shot 2020-11-13 at 14 08 36" src="https://user-images.githubusercontent.com/254753/99075487-dd7bfd00-25b9-11eb-851d-004ffcb2be30.png">

### Admin UI for real Text Paragraph

<img width="1226" alt="Screen Shot 2020-11-13 at 14 08 22" src="https://user-images.githubusercontent.com/254753/99075553-f5538100-25b9-11eb-8440-49618d0134a6.png">

### Admin UI for text field NOT inside Text Paragraph

(the highlight can be selected but is intentionally NOT honored)

<img width="1234"  style="width: 45%; float: left; " alt="Screen Shot 2020-11-13 at 14 07 24" src="https://user-images.githubusercontent.com/254753/99075587-02707000-25ba-11eb-8dce-ffed1481f8ab.png">

(highlight also NOT reflected on public theme)

<img width="929"    style="width: 45%; float: right; " alt="Screen Shot 2020-11-13 at 14 12 05" src="https://user-images.githubusercontent.com/254753/99075741-48c5cf00-25ba-11eb-9ffa-bf5ce62830ad.png">
