### PR TITLE
[GHO-64] Adjust ratio of hero image for articles

### DIFF
--- a/config/image.style.full_width_2_1_100.yml
+++ b/config/image.style.full_width_2_1_100.yml
@@ -1,0 +1,16 @@
+uuid: 41b4565d-39fa-4318-a384-9dbeee1679e1
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_100
+label: 'Full width - 2:1 - 100%'
+effects:
+  43325c5f-123b-44c1-ad53-4c524ac5be35:
+    uuid: 43325c5f-123b-44c1-ad53-4c524ac5be35
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1140
+      height: 570
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_105.yml
+++ b/config/image.style.full_width_2_1_105.yml
@@ -1,0 +1,16 @@
+uuid: 6479ffe3-f8d2-49a9-a725-4b910f3b209e
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_105
+label: 'Full width - 2:1 - 105%'
+effects:
+  873a35be-92a0-4c78-b154-8a0cdb63201d:
+    uuid: 873a35be-92a0-4c78-b154-8a0cdb63201d
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1200
+      height: 600
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_123.yml
+++ b/config/image.style.full_width_2_1_123.yml
@@ -1,0 +1,16 @@
+uuid: 406e58e1-a0ff-4418-8313-3cc8ba2017cc
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_123
+label: 'Full width - 2:1 - 123%'
+effects:
+  0cbcd713-f34e-4cca-b69e-4f97c66c6376:
+    uuid: 0cbcd713-f34e-4cca-b69e-4f97c66c6376
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1400
+      height: 700
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_133.yml
+++ b/config/image.style.full_width_2_1_133.yml
@@ -1,0 +1,16 @@
+uuid: ae118d05-82ca-4983-bae3-726a42ebaa89
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_133
+label: 'Full width - 2:1 - 133%'
+effects:
+  0e650ee7-04b6-4fb4-9bf3-5de0b80c7a21:
+    uuid: 0e650ee7-04b6-4fb4-9bf3-5de0b80c7a21
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1520
+      height: 760
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_180.yml
+++ b/config/image.style.full_width_2_1_180.yml
@@ -1,0 +1,16 @@
+uuid: b4dbc223-ccb3-44ea-9279-14165a0b1f44
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_180
+label: 'Full width - 2:1 - 180%'
+effects:
+  a153142d-e4cf-4971-8bfb-041f76111f33:
+    uuid: a153142d-e4cf-4971-8bfb-041f76111f33
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 2048
+      height: 1024
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_200.yml
+++ b/config/image.style.full_width_2_1_200.yml
@@ -1,0 +1,16 @@
+uuid: 1e1a31f7-613c-4a28-afe6-116ba5399e9f
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_200
+label: 'Full width - 2:1 - 200%'
+effects:
+  2c69b1c1-76cf-45b4-9db7-fbb2a4c6cb2b:
+    uuid: 2c69b1c1-76cf-45b4-9db7-fbb2a4c6cb2b
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 2280
+      height: 1140
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_210.yml
+++ b/config/image.style.full_width_2_1_210.yml
@@ -1,0 +1,16 @@
+uuid: 15b1ecc4-a528-45ab-9a7d-fb9ce8ce60c2
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_210
+label: 'Full width - 2:1 - 210%'
+effects:
+  420a9bc3-9d2f-4efc-a064-c9535790e53c:
+    uuid: 420a9bc3-9d2f-4efc-a064-c9535790e53c
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 2400
+      height: 1200
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_246.yml
+++ b/config/image.style.full_width_2_1_246.yml
@@ -1,0 +1,16 @@
+uuid: 7c77e1e6-db61-4942-8e66-189892b66972
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_246
+label: 'Full width - 2:1 - 246%'
+effects:
+  3a31fc3c-981f-4f7a-bcf8-5fe21ad9eb89:
+    uuid: 3a31fc3c-981f-4f7a-bcf8-5fe21ad9eb89
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 2800
+      height: 1400
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_50.yml
+++ b/config/image.style.full_width_2_1_50.yml
@@ -1,0 +1,16 @@
+uuid: c1f82258-b305-40e4-a9c8-0ad07713563b
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_50
+label: 'Full width - 2:1 - 50%'
+effects:
+  dcf0d8ac-ed6c-45e7-95bd-9d1c7bfcd235:
+    uuid: dcf0d8ac-ed6c-45e7-95bd-9d1c7bfcd235
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 570
+      height: 285
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_66.yml
+++ b/config/image.style.full_width_2_1_66.yml
@@ -1,0 +1,16 @@
+uuid: 6610019b-bf7c-4741-9a5a-f66471a7f5b3
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_66
+label: 'Full width - 2:1 - 66%'
+effects:
+  63c69228-ba30-487b-be57-74d52e1b5ef5:
+    uuid: 63c69228-ba30-487b-be57-74d52e1b5ef5
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 760
+      height: 380
+      anchor: center-center
+pipeline: __default__

--- a/config/image.style.full_width_2_1_90.yml
+++ b/config/image.style.full_width_2_1_90.yml
@@ -1,0 +1,16 @@
+uuid: 7e95a323-c78a-4b2f-beab-7672ccf4ac20
+langcode: en
+status: true
+dependencies: {  }
+name: full_width_2_1_90
+label: 'Full width - 2:1 - 90%'
+effects:
+  058d7bd0-1ea4-4ca8-b467-a6bf2f009393:
+    uuid: 058d7bd0-1ea4-4ca8-b467-a6bf2f009393
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 1024
+      height: 512
+      anchor: center-center
+pipeline: __default__

--- a/config/responsive_image.styles.hero_image.yml
+++ b/config/responsive_image.styles.hero_image.yml
@@ -3,58 +3,70 @@ langcode: en
 status: true
 dependencies:
   config:
-    - image.style.hero_desktop_x1
-    - image.style.hero_desktop_x2
-    - image.style.hero_mobile_x1
-    - image.style.hero_mobile_x2
-    - image.style.hero_tablet_x1
-    - image.style.hero_tablet_x2
-    - image.style.hero_xlarge_x1
-    - image.style.hero_xlarge_x2
+    - image.style.full_width_2_1_100
+    - image.style.full_width_2_1_105
+    - image.style.full_width_2_1_123
+    - image.style.full_width_2_1_133
+    - image.style.full_width_2_1_180
+    - image.style.full_width_2_1_210
+    - image.style.full_width_2_1_246
+    - image.style.full_width_2_1_50
+    - image.style.full_width_2_1_66
+    - image.style.full_width_90
   theme:
     - common_design
 id: hero_image
 label: 'Hero Image'
 image_style_mappings:
   -
+    breakpoint_id: common_design.xl
+    multiplier: 1x
+    image_mapping_type: image_style
+    image_mapping: full_width_2_1_123
+  -
+    breakpoint_id: common_design.xl
+    multiplier: 2x
+    image_mapping_type: image_style
+    image_mapping: full_width_2_1_246
+  -
     breakpoint_id: common_design.lg
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: hero_xlarge_x1
+    image_mapping: full_width_2_1_105
   -
     breakpoint_id: common_design.lg
     multiplier: 2x
     image_mapping_type: image_style
-    image_mapping: hero_xlarge_x2
+    image_mapping: full_width_2_1_210
   -
     breakpoint_id: common_design.md
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: hero_desktop_x1
+    image_mapping: full_width_90
   -
     breakpoint_id: common_design.md
     multiplier: 2x
     image_mapping_type: image_style
-    image_mapping: hero_desktop_x2
+    image_mapping: full_width_2_1_180
   -
     breakpoint_id: common_design.sm
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: hero_tablet_x1
+    image_mapping: full_width_2_1_66
   -
     breakpoint_id: common_design.sm
     multiplier: 2x
     image_mapping_type: image_style
-    image_mapping: hero_tablet_x2
+    image_mapping: full_width_2_1_133
   -
     breakpoint_id: common_design.xs
     multiplier: 1x
     image_mapping_type: image_style
-    image_mapping: hero_mobile_x1
+    image_mapping: full_width_2_1_50
   -
     breakpoint_id: common_design.xs
     multiplier: 2x
     image_mapping_type: image_style
-    image_mapping: hero_mobile_x2
+    image_mapping: full_width_2_1_100
 breakpoint_group: common_design
-fallback_image_style: hero_xlarge_x1
+fallback_image_style: full_width_2_1_50


### PR DESCRIPTION
Ticket: GHO-64

This simply adjusts the ratio of the hero images to `2:1`, adding corresponding image styles.

Note: this doesn't apply to the hero image of the homepage.