### PR TITLE
[GHO-94] Bug fixes following permission review

### DIFF
--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
+    - allowed_formats
     - double_field
     - inline_entity_form
     - layout_paragraphs
@@ -111,7 +112,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
     type: text_textarea
     region: content
   field_thumbnail_image:

--- a/config/core.entity_form_display.node.article.home_page.yml
+++ b/config/core.entity_form_display.node.article.home_page.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
+    - allowed_formats
     - layout_paragraphs
     - link
     - media_library
@@ -59,7 +60,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
     type: text_textarea
     region: content
   promote:

--- a/config/core.entity_form_display.node.story.default.yml
+++ b/config/core.entity_form_display.node.story.default.yml
@@ -23,7 +23,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
     type: text_textarea
     region: content
   field_media:
@@ -38,7 +41,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
     type: text_textarea
     region: content
   field_text:

--- a/config/core.entity_form_display.paragraph.image_with_text.default.yml
+++ b/config/core.entity_form_display.paragraph.image_with_text.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.paragraph.image_with_text.field_text
     - paragraphs.paragraphs_type.image_with_text
   module:
+    - allowed_formats
     - media_library
     - text
 id: paragraph.image_with_text.default
@@ -26,7 +27,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
     type: text_textarea
     region: content
 hidden:

--- a/config/core.entity_form_display.paragraph.section_index.default.yml
+++ b/config/core.entity_form_display.paragraph.section_index.default.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.paragraph.section_index.field_title
     - paragraphs.paragraphs_type.section_index
   module:
+    - allowed_formats
     - gho_fields
     - text
 id: paragraph.section_index.default
@@ -35,7 +36,10 @@ content:
     settings:
       rows: 5
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      allowed_formats:
+        hide_help: '1'
+        hide_guidelines: '1'
     type: text_textarea
     region: content
   field_title:

--- a/config/field.field.paragraph.further_reading.field_links.yml
+++ b/config/field.field.paragraph.further_reading.field_links.yml
@@ -18,6 +18,6 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
-  title: 1
+  link_type: 16
+  title: 2
 field_type: link

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoFurtherReadingLinkFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoFurtherReadingLinkFormatter.php
@@ -37,7 +37,7 @@ class GhoFurtherReadingLinkFormatter extends FormatterBase {
       $element[$delta] = [
         '#theme' => 'gho_further_reading_link_formatter',
         '#url' => $url,
-        '#title' => $item->title ?? $url->toString(),
+        '#title' => $item->title ?: $url->toString(),
         '#source' => $source,
       ];
     }

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldWidget/GhoFurtherReadingLinkWidget.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldWidget/GhoFurtherReadingLinkWidget.php
@@ -88,7 +88,7 @@ class GhoFurtherReadingLinkWidget extends LinkWidget {
    *   Form.
    */
   public static function validateSourceElement(array &$element, FormStateInterface $form_state, array $form) {
-    if ($element['uri']['#value'] !== '' && $element['title']['#value'] === '') {
+    if ($element['uri']['#value'] !== '' && $element['source']['#value'] === '') {
       $error = t('The @source field is required if there is @uri input.', [
         '@source' => $element['source']['#title'],
         '@uri' => $element['uri']['#title'],


### PR DESCRIPTION
Ticket: GHO-94

This PR does 2 things:

1. It hides all the "about text formats" below formatted text fields because it's useless as we don't allow text format selection
2. It fixes an issue with the source field validation for further reading links, fixes the display of the link title when none is provided just to be thorough as this cannot happen because of the third change: only allow external links and make link title mandatory.

Note: regarding the last point (external link and title), those were the original settings before moving the further reading links to a paragraph type where I overlooked the original settings:

<img width="615" alt="Screen Shot 2020-11-14 at 21 25 21" src="https://user-images.githubusercontent.com/696348/99146977-51083200-26c0-11eb-81ac-434b81c9f941.png">

## Testing

`drush cim`, `drush cr` and edit a story and check that there is no "about text format" below the `footnotes` and `source` fields and add a further reading paragraph and test with internal link, missing title, missing source etc.