### PR TITLE
[GHO-103] Enable caption styling for blockquotes inside text paragraphs

### DIFF
--- a/html/themes/custom/common_design_admin_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_admin_subtheme/css/styles.css
@@ -33,9 +33,15 @@
   font-weight: 700;
   line-height: 2.25rem;
 }
+.paragraph--type--text blockquote {
+  margin: 1.5rem 0;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  color: #707070;
+}
 
 /* this is inside other stuff like Story */
-.field--type-text-long {
+.paragraph .field--type-text-long {
   max-width: 720px;
 }
 

--- a/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
@@ -6,3 +6,9 @@
   font-weight: 700;
   line-height: 2.25rem;
 }
+.paragraph--type--text blockquote {
+  margin: 2rem 0;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #707070;
+}

--- a/html/themes/custom/common_design_subtheme/css/ckeditor/styles.css
+++ b/html/themes/custom/common_design_subtheme/css/ckeditor/styles.css
@@ -3,3 +3,10 @@ p.highlight {
   font-weight: 700;
   line-height: 2.25rem;
 }
+
+blockquote {
+  margin: 2rem 0;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  color: #707070;
+}


### PR DESCRIPTION
Ticket: GHO-103

This enables the caption styling for blockquotes inside text paragraphs.

Not sure about the margins because there is no example of pull quotes in any of the documents.