### PR TITLE
[GHO-59][GHO-61] Visual adjustments

### DIFF
--- a/html/modules/custom/gho_fields/gho_fields.module
+++ b/html/modules/custom/gho_fields/gho_fields.module
@@ -38,6 +38,7 @@ function gho_fields_theme() {
         'location' => NULL,
         'caption' => NULL,
         'credits' => NULL,
+        'attributes' => NULL,
       ],
     ],
   ];

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoCaptionFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoCaptionFormatter.php
@@ -4,6 +4,7 @@ namespace Drupal\gho_fields\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Template\Attribute;
 
 /**
  * Plugin implementations for 'gho_caption' formatter.
@@ -30,6 +31,7 @@ class GhoCaptionFormatter extends FormatterBase {
         '#caption' => $item->second,
         // This is needs to be set in a hook_preprocess_gho_caption_formatter().
         '#credits' => NULL,
+        '#attributes' => new Attribute(),
         '#theme' => 'gho_caption_formatter',
       ];
     }

--- a/html/modules/custom/gho_fields/templates/gho-caption-formatter.html.twig
+++ b/html/modules/custom/gho_fields/templates/gho-caption-formatter.html.twig
@@ -1,10 +1,10 @@
-<div class="gho-caption">
-  <p class="gho-caption__location location">{{ location }}</p>
+<div{{ attributes.addClass('gho-caption') }}>
+  <p class="gho-caption__location">{{ location }}</p>
   {% spaceless %}
-  <p class="gho-caption__caption caption">
+  <p class="gho-caption__text">
     {{ caption }}
     {% if credits %}
-      <span class="gho-caption__credits credits">{{ credits }}</span>
+      <span class="gho-caption__credits">{{ credits }}</span>
     {% endif %}
   </p>
   {% endspaceless %}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -76,6 +76,11 @@ gho-needs-and-requirements:
     theme:
       components/gho-needs-and-requirements/gho-needs-and-requirements.css: {}
 
+gho-caption:
+  css:
+    theme:
+      components/gho-caption/gho-caption.css: {}
+
 gho-bleed:
   header: true
   js:
@@ -90,6 +95,7 @@ gho-aside:
       components/gho-aside/gho-aside.css: {}
   dependencies:
     - common_design_subtheme/gho-bleed
+    - common_design_subtheme/gho-caption
 
 gho-hero-image:
   css:

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -8,8 +8,9 @@
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
-use Drupal\node\NodeInterface;
+use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
 use Drupal\gho_fields\Plugin\Field\FieldFormatter\GhoRelatedArticlesFormatter;
 
 /**
@@ -193,7 +194,9 @@ function common_design_subtheme_preprocess_node__story(&$variables) {
  * Show the related articles at the end of the main articles.
  */
 function common_design_subtheme_preprocess_node__article(&$variables) {
-  if (isset($variables['view_mode']) && $variables['view_mode'] === 'full') {
+  $view_mode = $variables['view_mode'] ?? '';
+  // Main articles.
+  if ($view_mode === 'full') {
     $node_id = $variables['node']->id();
     $node_uri = 'entity:node/' . $node_id;
 
@@ -202,7 +205,7 @@ function common_design_subtheme_preprocess_node__article(&$variables) {
       $credits = $variables['content']['field_hero_image'][0]['#media']->field_credits->value;
       $variables['content']['field_caption'][0]['#credits'] = ['#markup' => $credits];
     }
-    
+
     // Show the footnotes at the bottom of the article page, before the
     // related articles.
     $variables['content']['footnotes'] = gho_footnotes_build_footnotes();
@@ -233,6 +236,19 @@ function common_design_subtheme_preprocess_node__article(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_paragraph__sub_article().
+ *
+ * Add a class to the sub-article paragraph indicating whether the article has
+ * a hero or not as it's difficult to access from within the twig templates.
+ */
+function common_design_subtheme_preprocess_paragraph__sub_article(&$variables) {
+  if (isset($variables['content']['field_article'][0]['#node'])) {
+    $hero = $variables['content']['field_article'][0]['#node']->field_hero_image->target_id;
+    $variables['attributes']['class'][] = 'gho-sub-article-paragraph--' . ($hero ? 'hero' : 'no-hero');
+  }
+}
+
+/**
  * Implements hook_preprocess_paragraph__image_with_text().
  *
  * Extract the media credits to display them after the text.
@@ -242,6 +258,18 @@ function common_design_subtheme_preprocess_paragraph__image_with_text(&$variable
     $credits = $variables['content']['field_image'][0]['#media']->field_credits->value;
     $variables['content']['credits'] = ['#markup' => $credits];
   }
+}
+
+/**
+ * Implements hook_preprocess_field__node__field_caption__article().
+ *
+ * Add a class to identify the article caption.
+ */
+function common_design_subtheme_preprocess_field__node__field_caption__article(&$variables) {
+  if (!isset($variables['items'][0]['content']['#attributes'])) {
+    $variables['items'][0]['content']['#attributes'] = new Attribute();
+  }
+  $variables['items'][0]['content']['#attributes']->addClass('gho-caption--article');
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/gho-appeals-tags.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-appeals-tags/gho-appeals-tags.css
@@ -11,15 +11,20 @@
  * Individual tag
  */
 .gho-appeals-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex: 0 0 auto;
+  width: 2.5rem;
+  height: 1rem;
   margin: 0 .25rem;
-  min-width: 4em;
-  display: inline-block;
-  text-align: center;
   background: #5090cd;
   color: #fff;
-  font-size: .75em;
+  font-size: .5625em;
   font-weight: 700;
+  letter-spacing: 100;
+  text-align: center;
+  text-transform: uppercase;
 }
 
 .gho-appeals-tag--hrp {
@@ -28,12 +33,16 @@
 .gho-appeals-tag--fa {
   background-color: #8869ae;
 }
-.gho-appeals-tag--rrp {
-  background-color: #e66751;
+.gho-appeals-tag--rrp,
+.gho-appeals-tag--3rp {
+  background-color: #d85f49;
 }
-.gho-appeals-tag--rmrp {
-  background-color: #f9a356;
+.gho-appeals-tag--rmrp,
+.gho-appeals-tag--mrp,
+.gho-appeals-tag--jrp {
+  background-color: #f9a456;
 }
-.gho-appeals-tag--other {
-  background-color: #87cfad;
+.gho-appeals-tag--other,
+.gho-appeals-tag--covid {
+  background-color: #65c296;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-article/gho-article.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article/gho-article.css
@@ -10,61 +10,83 @@
 
 .gho-article__header {
   position: relative;
+  z-index: 0;
+}
+/* Article hero image dimensions are based on the full width (1140px) not the
+ * content width (904px). */
+@media (min-width: 1400px) {
+  .gho-article__header .gho-hero-image.gho-bleed {
+    margin-left: -130px;
+    margin-right: -130px;
+  }
 }
 .gho-article__heading {
+  max-width: var(--content-width);
   padding: 2rem 0 0 0;
+  margin: 0 auto;
 }
-@media (min-width: 1200px) {
-  .gho-article--with-hero-image .gho-article__heading {
+/* Take into account the 8px grey margins: 1040px + 2 * 8x. */
+@media (min-width: 1056px) {
+  .gho-article--hero .gho-article__heading {
+    position: relative;
+    margin-top: -190px;
+    z-index: 1;
+  }
+  .gho-article--hero .gho-article__heading::before {
+    content: "";
     position: absolute;
-    bottom: 0;
-    left: -2rem;
-    right: -2rem;
-    padding: 1rem 2rem;
-    background: white;
+    top: 0;
+    left: -68px;
+    width: 1040px;
+    height: 190px;
+    background: #fff;
+    z-index: -1;
   }
 }
 
 .gho-article__pre-title {
-  max-width: 480px;
-  margin-bottom: 0.5rem;
-  color: #6d6d6d;
+  max-width: var(--reading-width);
+  margin-bottom: 1rem;
+  color: #707070;
+  font-size: 0.875rem;
+}
+@media (min-width: 1024px) {
+  .gho-article__pre-title {
+    margin-bottom: 1.5rem;
+  }
 }
 .gho-article .page-title {
-  max-width: 480px;
+  max-width: var(--reading-width);
   padding: 0;
-  margin: 0;
+  margin: 0 0 3rem 0;
   border: none;
-  font-size: 2.625rem;
-  color: black;
+  font-size: 2.25rem;
+  line-height: 2.375rem;
+  color: #1f1f1f;
 }
 @media (min-width: 768px) {
   .gho-article .page-title {
+    font-size: 2.875rem;
+    line-height: 3.125rem;
+  }
+}
+@media (min-width: 1024px) {
+  .gho-article .page-title {
     font-size: 3.25rem;
+    line-height: 3.375rem;
   }
 }
 
-.gho-article .gho-article__local_tasks {
-  margin-top: 2rem;
+.gho-article__content {
+  position: relative;
+  max-width: var(--content-width);
+  margin: 0 auto;
+  z-index: 1;
 }
 
-/* @todo Move that in a `gho-caption` component? */
-/* Bonus: the styles below apply to the sub-articles as well. */
-.gho-article .gho-caption {
-  max-width: var(--reading-width);
-  /* @todo adjust margin-top after reviewing title's margins. */
-  margin: 2rem 0;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  color: #6d6d6d;
-}
-.gho-article .gho-caption__location {
-  margin-bottom: 0;
-  font-weight: bold;
-}
-.gho-article .gho-caption__caption {
-  margin-top: 0;
-}
-.gho-article .gho-caption__credits {
-  font-style: italic;
+.gho-article__local_tasks {
+  position: relative;
+  max-width: var(--content-width);
+  margin: 2rem auto;
+  z-index: 1;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-aside/gho-aside.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-aside/gho-aside.css
@@ -1,23 +1,27 @@
 .gho-aside {
-  margin-top: 2em;
-  margin-bottom: 2em;
+  margin-top: 6.75rem;
+  margin-bottom: 4.5rem;
 }
 .gho-aside * {
-  color: #6d6d6d;
+  color: #707070;
 }
 .gho-aside--dark {
+  padding: 2.5rem 0 3rem 0;
   background-color: #1f1f1f;
 }
 .gho-aside--dark * {
-  color: #ddd;
+  color: #fff;
 }
 .gho-aside__pre-title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5rem;
   display: block;
 }
 .gho-aside__title {
   margin-top: 0;
-  /* 18px. */
-  font-size: 1.125rem;
+  margin-bottom: 1.5rem;
+  font-size: 1rem;
   font-weight: 700;
-  line-height: 1.5;
+  line-height: 1.5rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-author/gho-author.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-author/gho-author.css
@@ -2,47 +2,32 @@
  * Base Author field
  */
 .gho-author .media {
-  float: left;
-  display: block;
-  margin: 1em 0;
+  display: flex;
+  align-items: center;
   max-width: 580px;
+  color: #1f1f1f;
+  font-size: 0.875rem;
+  line-height: 1.375rem;
 }
 
-[dir='rtl'] .gho-author .media {
-  float: right;
-  text-align: right;
+.gho-author__image {
+  width: 60px;
+  height: 60px;
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: 60px;
 }
-
-.gho-author .media picture {
-  width: 25%;
-  max-width: 100px;
-  max-height: 100px;
-  margin-bottom: 4em;
-}
-@media screen and (min-width: 550px) {
-  .gho-author .media picture {
-    margin-bottom: 0;
-  }
-}
-
-[dir='ltr'] .gho-author .media picture {
-  float: left;
-  margin-right: 1em;
-}
-[dir='rtl'] .gho-author .media picture {
-  float: right;
-  margin-left: 1em;
-}
-
-.gho-author .media img {
+.gho-author__image img {
   border-radius: 50%;
 }
 
-.gho-author .field--name-name {
-  font-weight: 700;
+[dir='ltr'] .gho-author__content {
+  margin-left: 1.5rem;
 }
-@media screen and (min-width: 550px) {
-  .gho-author .field--name-name {
-    padding-top: 1em;
-  }
+[dir='rtl'] .gho-author__content {
+  margin-right: 1.5rem;
+}
+
+.gho-author__content .field--name-name {
+  font-weight: 700;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-bleed/gho-bleed.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-bleed/gho-bleed.css
@@ -27,9 +27,9 @@
 
 @media screen and (min-width: 1400px) {
   .gho-bleed {
-    /* Limit to the maxium width of the body. */
-    margin-left: -130px;
-    margin-right: -130px;
+    /* Limit to the maxium width of the body: (1400 - 904) / 2*/
+    margin-left: -248px;
+    margin-right: -248px;
   }
 }
 
@@ -39,7 +39,7 @@
 .gho-bleed--background-only {
   position: relative;
   z-index: 1;
-  padding: 1em 0;
+  padding: 0;
 }
 
 .gho-bleed--background-only:before {
@@ -57,9 +57,6 @@
 }
 
 @media screen and (min-width: 1024px) {
-  .gho-bleed--background-only {
-    padding: 2em 0;
-  }
   .gho-bleed--background-only:before {
     /* Include the grey margin. */
     margin-left: calc(50% + 8px - 50vw + var(--gho-bleed-scrollbar-width) / 2);
@@ -69,8 +66,8 @@
 
 @media screen and (min-width: 1400px) {
   .gho-bleed--background-only:before {
-    /* Limit to the maxium width of the body. */
-    margin-left: -130px;
-    margin-right: -130px;
+    /* Limit to the maxium width of the body: (1400 - 904) / 2*/
+    margin-left: -248px;
+    margin-right: -248px;
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-bottom-figure-row/gho-bottom-figure-row.css
@@ -1,60 +1,65 @@
 /**
  * Base field.
  */
-.gho-bottom-figure-row {
-  /* Same margins as the aside components for consistency. */
+ .gho-bottom-figure-row {
+  padding-top: 2rem;
   margin-top: 2rem;
-  margin-bottom: 2rem;
+  border-top: 1px solid #ccc;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
 }
-.gho-bottom-figure-row .field__items {
+
+.gho-bottom-figure-row__figures {
   display: flex;
   flex-flow: row wrap;
   justify-content: flex-start;
   align-content: space-around;
   overflow-x: hidden;
+  /* Compensate for the margins of the fiedl__item.*/
+  margin: -1rem 0 0 0;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid #ccc;
 }
 
-.gho-bottom-figure-row .field__items > .field__item {
+.gho-bottom-figure-row__figure {
   flex: 0 1 auto;
   min-width: 140px;
-  margin: 1rem 0;
+  margin: 1rem 0 0 0;
 }
-[dir='ltr'] .gho-bottom-figure-row .field__items > .field__item {
+[dir='ltr'] .gho-bottom-figure-row__figure {
   /* The left margin combined with the overflow-x: hidden of the parent
    * ensures the left border and padding are hidden for the first item of each
    * row. */
   margin-left: calc(-1rem - 1px);
   padding: 0 2rem 0 1rem;
-  border-left: 1px solid #ddd;
+  border-left: 1px solid #ccc;
 }
-[dir='rtl'] .gho-bottom-figure-row .field__items > .field__item {
+[dir='rtl'] .gho-bottom-figure-row__figure {
   /* The right margin combined with the overflow-x: hidden of the parent
    * ensures the right border and padding are hidden for the first item of each
    * row. */
   margin-right: calc(-1rem - 1px);
   padding: 0 1rem 0 2rem;
-  border-right: 1px solid #ddd;
+  border-right: 1px solid #ccc;
 }
 
 @media screen and (min-width: 768px) {
-  [dir='ltr'] .gho-bottom-figure-row .field__items > .field__item:first-child {
+  [dir='ltr'] .gho-bottom-figure-row__figure:first-child {
     border-left: 0;
   }
-  [dir='rtl'] .gho-bottom-figure-row .field__items > .field__item:first-child {
+  [dir='rtl'] .gho-bottom-figure-row__figure:first-child {
     border-right: 0;
   }
 }
 
-.gho-bottom-figure-row .double-field-first,
-.gho-bottom-figure-row .double-field-second {
+.gho-bottom-figure-row__figure .double-field-first,
+.gho-bottom-figure-row__figure .double-field-second {
   display: block;
 }
-
-.gho-bottom-figure-row .double-field-first {
+.gho-bottom-figure-row__figure .double-field-first {
   font-weight: 700;
 }
 
-.gho-bottom-figure-row .gho-dataset-link {
-  padding-top: 1rem;
-  border-top: 1px solid #ddd;
+.gho-bottom-figure-row__source {
+  margin-top: 1rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-caption/gho-caption.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-caption/gho-caption.css
@@ -1,0 +1,43 @@
+.gho-caption {
+  /* Margin top and bottom vary depending on where the caption is used, so
+   * we let the components using them to set their margins. */
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  color: #707070;
+}
+@media (min-width: 768px) {
+  .gho-caption {
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+  }
+}
+.gho-caption--article {
+  padding-bottom: 2rem;
+  margin-bottom: 4.5rem;
+  border-bottom: 1px solid #d8d8d8;
+}
+/* We don't put the max-width on the container so we can more easily add
+ * the border bottom for the article captions.*/
+.gho-caption > * {
+  max-width: var(--reading-width);
+}
+.gho-caption__location {
+  margin: 0;
+  font-weight: bold;
+}
+.gho-caption__text {
+  margin: 0;
+}
+.gho-caption__text > :first-child {
+  margin-top: 0;
+}
+.gho-caption__text > :last-child {
+  margin-bottom: 0;
+}
+.gho-caption--formatted .gho-caption__text > p:last-of-type {
+  display: inline;
+}
+.gho-caption__credits {
+  font-style: italic;
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-facts-and-figures/gho-facts-and-figures.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-facts-and-figures/gho-facts-and-figures.css
@@ -1,22 +1,23 @@
 /**
  * Base facts and figures.
  */
+.gho-facts-and-figures {
+  max-width: var(--content-width);
+}
 .gho-facts-and-figures .field--name-field-paragraphs {
   /* Compensate for the padding of the image and text paragraphs */
-  margin: -0.5rem;
+  margin: -0.625rem;
 }
 .gho-facts-and-figures .field--name-field-paragraphs > .field__item {
-  padding: 0.5rem;
+  padding: 0.625rem;
 }
 
 .gho-facts-and-figures__caption {
-  margin-top: 1rem;
+  margin-top: 1.5rem;
 }
-.gho-facts-and-figures__caption > p:last-of-type {
-  display: inline;
-}
-.gho-facts-and-figures__credits {
-  font-style: italic;
+
+.gho-facts-and-figures .field--name-field-paragraphs > .field__item + .field__item {
+  margin-top: 1.5rem;
 }
 
 /**
@@ -34,5 +35,8 @@
   }
   .gho-facts-and-figures .field--name-field-paragraphs > .field__item {
     flex: 0 0 33.33%;
+  }
+  .gho-facts-and-figures .field--name-field-paragraphs > .field__item + .field__item {
+    margin-top: 0;
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
@@ -2,23 +2,34 @@
  * Base component styles
  */
 .gho-further-reading {
-  max-width: 720px; /* reading-width */
-  margin-bottom: 2rem;
+  max-width: var(--reading-width);
+  margin: 6.75rem 0;
+  color: #1f1f1f;
 }
 
 /**
  * Title
  */
 .gho-further-reading__title {
-  color: black;
+  margin-bottom: 1.5rem;
+  font-size: 1.25rem;
+  color: #1f1f1f;
+}
+@media (min-width: 1024px) {
+  .gho-further-reading__title {
+    margin-bottom: 1.5rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+  }
 }
 
 /**
  * Style list of links
  */
 .gho-further-reading__link {
-  border-top: 1px solid #ccc;
   position: relative; /* for SVG @see gho_fields/templates */
+  border-top: 1px solid #ccc;
+  font-size: 0.875rem;
 }
 
 /**
@@ -36,7 +47,9 @@
  */
 .gho-further-reading a {
   display: block;
+  font-size: inherit;
   font-weight: 700;
+  line-height: 1.25rem;
   padding: 1rem 0 3rem;
 }
 
@@ -48,7 +61,7 @@
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  fill: black;
+  fill: #1f1f1f;
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/gho-home-page/gho-home-page.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-home-page/gho-home-page.css
@@ -21,11 +21,6 @@
   margin-bottom: 0;
 }
 
-.gho-home-page .node__content {
-  margin: 0; /* work with gho-bleed */
-  position: relative; /* for summary/link */
-}
-
 .gho-home-page__header {
   position: relative;
 }
@@ -40,6 +35,14 @@
   justify-content: center;
   align-items: center;
 }
+/* Home page hero image dimensions are based on the full width (1140px) not the
+ * content width (904px). */
+@media (min-width: 1400px) {
+  .gho-home-page__header .gho-hero-image.gho-bleed {
+    margin-left: -130px;
+    margin-right: -130px;
+  }
+}
 
 /* if we want a much more gradual font-size increase, use the two commented props
    in this rule (font-size/max-width) and then comment all media queries. */
@@ -48,7 +51,7 @@
   max-width: 285px;
   /*max-width: 15ch;*/
   margin-bottom: 1rem;
-  color: white;
+  color: #fff;
   font-size: 1.2em;
   /*font-size: calc(.8em + 3vw);*/
   line-height: 1;
@@ -87,8 +90,8 @@
 
 .gho-home-page__link {
   display: block;
-  color: white;
-  border: 1px solid white;
+  color: #fff;
+  border: 1px solid #fff;
   padding: .5rem;
   font-size: .75em;
   font-weight: 700;
@@ -97,29 +100,39 @@
 }
 
 .gho-home-page__link:hover {
-  color: white;
+  color: #fff;
   text-decoration: underline;
+}
+.gho-home-page__content {
+  max-width: var(--content-width);
+  margin: 0 auto;
+}
+
+.gho-home_page__local_tasks {
+  position: relative;
+  max-width: var(--content-width);
+  margin: 2rem auto;
+  z-index: 1;
 }
 
 /**
  * Special handling of the first sub-article on the homepage which for some
  * reason has a smaller font-size for its title according to the design doc.
  */
-.gho-home-page .field--name-field-paragraphs > :first-child .gho-sub-article__header {
+.gho-home-page__content .gho-sub-article-paragraph:first-child {
+  margin-top: 3rem;
   padding-top: 0;
   border-top: 0;
 }
-.gho-home-page .field--name-field-paragraphs > :first-child .gho-sub-article__title {
-  margin-bottom: 0.5rem;
-  font-size: 1.5rem;
+.gho-home-page__content .gho-sub-article-paragraph:first-child .gho-sub-article__header {
+  margin-bottom: 2rem;
 }
-/**
- * Try to have the content on the homepage have the same width.
- * @todo review if it's ok for the text paragraphs.
- */
-.gho-home-page .gho-sub-article__title {
-  max-width: var(--content-width);
+.gho-home-page__content .gho-sub-article-paragraph:first-child .gho-sub-article__title {
+  font-size: 1.25rem;
+  line-height: 2rem;
 }
-.gho-home-page .paragraph--type--text {
-  max-width: var(--content-width);
+@media (min-width: 1024px) {
+  .gho-home-page__content .gho-sub-article-paragraph:first-child .gho-sub-article__title {
+    font-size: 1.5rem;
+  }
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.css
@@ -1,5 +1,10 @@
+.gho-interactive-content {
+  margin-top: 3rem;
+  margin-bottom: 3rem;
+}
 .gho-interactive-content .field--name-field-image {
   max-width: var(--content-width);
+  margin-bottom: 1.5rem;
 }
 .gho-interactive-content .gho-dataset-link {
   margin-top: 1rem;

--- a/html/themes/custom/common_design_subtheme/components/gho-needs-and-requirements/gho-needs-and-requirements.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-needs-and-requirements/gho-needs-and-requirements.css
@@ -1,15 +1,17 @@
 .gho-needs-and-requirements {
   max-width: var(--content-width);
-  margin-top: 2em;
-  margin-bottom: 2em;
 }
 .gho-needs-and-requirements-figure {
-  padding: 1em 0;
+  padding: 2rem 0;
   border-style: solid;
   border-color: #ccc;
   border-width: 1px 0 0 0;
 }
+.gho-needs-and-requirements-figure:last-child {
+  padding-bottom: 0;
+}
 .gho-needs-and-requirements-figure__label {
+  font-size: 1rem;
   font-weight: bold;
 }
 .gho-needs-and-requirements-figure__label small {
@@ -17,9 +19,9 @@
   font-weight: normal;
 }
 .gho-needs-and-requirements-figure__value {
-  font-weight: bold;
-  font-size: 2.25rem;
   color: #5391cb;
+  font-size: 1.625rem;
+  font-weight: bold;
 }
 
 @media (min-width: 768px) {
@@ -27,13 +29,15 @@
     display: flex;
     justify-content: space-between;
     border-top: 1px solid #ccc;
-    padding-top: 1.5rem;
+    padding-top: 2rem;
   }
   .gho-needs-and-requirements-figure {
     display: inline-block;
-    flex: 1 0 33.33%;
+    flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: 33.33%;
     border-width: 0 0 0 1px;
-    padding: 0 1.5em;
+    padding: 0 1.5rem;
   }
   [dir="ltr"] .gho-needs-and-requirements-figure:first-child {
     border-width: 0;
@@ -44,5 +48,16 @@
   }
   [dir="rtl"] .gho-needs-and-requirements-figure:last-child {
     border-width: 0;
+  }
+  .gho-needs-and-requirements-figure__label {
+    font-size: 1.125rem;
+  }
+  .gho-needs-and-requirements-figure__value {
+    font-size: 2rem;
+  }
+}
+@media (min-width: 1024px) {
+  .gho-needs-and-requirements-figure__value {
+    font-size: 2.25rem;
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/gho-photo-gallery.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-photo-gallery/gho-photo-gallery.css
@@ -3,20 +3,10 @@
  */
 .gho-photo-gallery .field--name-field-photos {
   /* Compensate for the padding of the photos */
-  margin: 0 -0.5rem;
+  margin: -0.75rem -0.625rem;
 }
 .gho-photo-gallery .field--name-field-photos > .field__item {
-  padding: 0.5rem;
-}
-.gho-photo-gallery__location {
-  margin-bottom: 0;
-  font-weight: bold;
-}
-.gho-photo-gallery__caption {
-  margin-top: 0;
-}
-.gho-photo-gallery__credits {
-  font-style: italic;
+  padding: 0.75rem 0.625rem;
 }
 
 /**
@@ -37,7 +27,7 @@
  * smaller screens.
  */
 .gho-photo-gallery--two-columns {
-  max-width: var(--reading-width);
+  max-width: var(--content-width);
 }
 @media screen and (min-width: 768px) {
   .gho-photo-gallery--two-columns .field--name-field-photos {
@@ -52,4 +42,11 @@
     flex-shrink: 0;
     flex-basis: calc(50% - 1rem);
   }
+}
+
+/**
+ * Caption below images.
+ */
+.gho-photo-gallery .gho-caption {
+  margin-top: 2rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-related-articles/gho-related-articles.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-related-articles/gho-related-articles.css
@@ -3,23 +3,25 @@
  */
 .gho-related-articles {
   max-width: var(--content-width);
+  margin: 6.75rem 0;
+  padding: 4.5rem 0 0 0;
+  border-top: 1px solid #ccc;
 }
 
 /**
  * List title
  */
 .gho-related-articles__title {
-  margin: 2rem 0 0.5rem 0;
-  padding: 2rem 0 0 0;
-  border-top: 1px solid #ccc;
-  color: black;
+  margin: 0;
+  color: #1f1f1f;
+  font-weight: 700;
 }
 
 /**
  * Individual Article
  */
 .gho-related-article {
-  padding: 1.5rem 0;
+  margin-top: 2rem;
 }
 @media screen and (min-width: 768px) {
   .gho-related-article {
@@ -34,6 +36,7 @@
  * Lists of related articles have separators
  */
 .gho-related-article + .gho-related-article {
+  padding-top: 2rem;
   border-top: 1px solid #ccc;
 }
 
@@ -42,8 +45,8 @@
  */
 @media screen and (min-width: 768px) {
   .gho-related-article .field--name-field-thumbnail-image {
-    /* The 2rem are for the padding of the text */
-    width: calc(40% - 2rem);
+    /* The 2.25rem are for the padding of the text */
+    width: calc(40% - 2.25rem);
     min-width: 320px;
   }
 }
@@ -61,12 +64,12 @@
     flex-basis: 320px;
   }
   [dir='ltr'] .gho-related-article__content {
-    padding-left: 2rem;
+    padding-left: 2.25rem;
     padding-right: 0;
   }
   [dir='rtl'] .gho-related-article__content {
     padding-left: 0;
-    padding-right: 2rem;
+    padding-right: 2.25rem;
   }
 }
 
@@ -79,7 +82,7 @@
   margin: 1rem 0;
 }
 .gho-related-article__title a {
-  color: black;
+  color: #1f1f1f;
   text-decoration: none;
 }
 @media screen and (min-width: 768px) {

--- a/html/themes/custom/common_design_subtheme/components/gho-section-index/gho-section-index.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-section-index/gho-section-index.css
@@ -1,30 +1,50 @@
 .gho-section-index {
   max-width: var(--content-width);
-}
-/* This is similar to the sub-article styling */
-.gho-section-index__header {
-  margin: 2rem 0 1rem 0;
+  margin: 3rem 0;
   padding: 2rem 0 0 0;
   border-top: 1px solid #ccc;
 }
+/* This is similar to the sub-article styling */
+.gho-section-index__header {
+  margin: 0 0 1rem 0;
+}
 .gho-section-index__pre-title {
+  display: block;
   margin-bottom: 0.5rem;
-  color: #6d6d6d;
+  color: #707070;
 }
 .gho-section-index__title {
   margin: 0;
   padding: 0;
-  color: black;
-  font-size: 2rem;
+  font-size: 1.625rem;
+  line-height: 1.75rem;
   font-weight: 700;
+  color: #1f1f1f;
 }
-/* @todo check if  we need to limit the width of the description. This doesn't
- * seem to be the case on the homepage. */
-.gho-section-index .field--name-field-text {
-   /* max-width: var(--reading-width); */
-   margin-bottom: 1rem;
- }
-
-.gho-section-index .gho-related-article {
-  border-top: 1px solid #ccc;
+@media (min-width: 768px) {
+  .gho-section-index__title {
+    font-size: 2.25rem;
+    line-height: 2.5rem;
+  }
+}
+.gho-section-index__description {
+  margin-top: 3rem;
+  font-size: 1rem;
+  line-height: 1.75rem;
+}
+@media (min-width: 768px) {
+  .gho-section-index__description {
+    font-size: 1.125rem;
+    line-height: 2rem;
+  }
+}
+.gho-section-index__description p:first-child {
+  margin-top: 0;
+}
+.gho-section-index__description p:last-child {
+  margin-bottom: 0;
+}
+.gho-section-index .gho-related-articles {
+  margin-top: 3rem;
+  padding-top: 0;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-story/gho-story.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-story/gho-story.css
@@ -1,14 +1,11 @@
 .gho-story--teaser {
   max-width: var(--reading-width);
 }
-.gho-story__caption {
-  margin: 1rem 0;
+.gho-story .field--name-field-media {
+  margin-bottom: 2.5rem;
 }
-.gho-story__caption > p:last-of-type {
-  display: inline;
-}
-.gho-story__credits {
-  font-style: italic;
+.gho-story .gho-caption {
+  margin: 0;
 }
 .gho-story__source {
   border-top: 1px solid #ccc;
@@ -28,4 +25,11 @@
 .gho-story__source .item-list li {
   list-style: none;
   margin: 0;
+}
+
+.gho-story__local_tasks {
+  position: relative;
+  max-width: var(--content-width);
+  margin: 2rem auto;
+  z-index: 1;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-sub-article/gho-sub-article.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-sub-article/gho-sub-article.css
@@ -1,42 +1,51 @@
 /**
  * Base styles
  */
-.gho-sub-article__header {
-  /* The negative bottom margin is to compensate for the one from the title
-   * or the appeals tags. */
-  margin: 2rem 0 -1rem 0;
-  padding: 2rem 0 0 0;
+.gho-sub-article-paragraph--no-hero {
+  margin-top: 6.75rem;
+  padding-top: 4.5rem;
   border-top: 1px solid #ccc;
 }
-.gho-sub-article--with-hero-image .gho-sub-article__header {
-  margin-top: 2rem;
+.gho-sub-article-paragraph--hero {
+  margin-top: 6.75rem;
+}
+.gho-caption--article + .gho-sub-article-paragraph {
+  margin-top: 4.5rem;
   padding-top: 0;
   border-top: none;
 }
-.gho-sub-article--with-hero-image .gho-hero-image {
-  margin-bottom: 2rem;
+.gho-sub-article--hero .gho-hero-image {
+  margin-bottom: 3rem;
+}
+.gho-sub-article__header {
+  margin-bottom: 3rem;
+}
+.gho-sub-article__heading {
+  /* The negative bottom margin is to compensate for the one from the title
+   * or the appeals tags. */
+  margin: 0 0 -1rem 0;
 }
 .gho-sub-article__title {
   display: inline-block;
-  max-width: 720px; /* reading-width */
+  max-width: var(--reading-width);
   /* The bottom margin is to ensure the appeals tag are displayed nicely below
    * the title on smaller screens. */
   margin: 0 0 1rem 0;
   padding: 0;
-  color: black;
+  color: #1f1f1f;
   font-size: 2rem;
   font-weight: 700;
-}
-.gho-sub-article .gho-appeals-tags {
-  display: inline-block;
-  vertical-align: top;
-  margin: 0 0 1rem;
-}
-.gho-sub-article .gho-appeals-tag {
-  vertical-align: top;
 }
 @media (min-width: 768px) {
   .gho-sub-article__title {
     font-size: 2.625rem;
   }
+}
+.gho-sub-article__heading .gho-appeals-tags {
+  display: inline-block;
+  vertical-align: top;
+  margin: 0 0 1rem;
+}
+.gho-sub-article__heading .gho-appeals-tag {
+  vertical-align: top;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
@@ -1,8 +1,29 @@
 .paragraph--type--text {
   max-width: var(--reading-width);
+  margin: 4.5rem 0 0 0;
+  font-size: 1;
+  line-height: 1.75rem;
+}
+@media (min-width: 768px) {
+  .paragraph--type--text {
+    font-size: 1.125rem;
+    line-height: 2rem;
+  }
 }
 .paragraph--type--text p.highlight {
-  font-size: 1.5rem;
+  font-size: 1.25rem;
   font-weight: 700;
-  line-height: 2.25rem;
+  line-height: 2rem;
+}
+@media (min-width: 1024px) {
+  .paragraph--type--text p.highlight {
+    font-size: 1.5rem;
+    line-height: 2.25rem;
+  }
+}
+.paragraph--type--text .field--name-field-text > :first-child {
+  margin-top: 0;
+}
+.paragraph--type--text .field--name-field-text > :last-child {
+  margin-bottom: 0;
 }

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-paragraphs--article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--node--field-paragraphs--article.html.twig
@@ -1,0 +1,3 @@
+{%- for item in items -%}
+  {{ item.content }}
+{%- endfor -%}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-bottom-figures--bottom-figure-row.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-bottom-figures--bottom-figure-row.html.twig
@@ -1,0 +1,7 @@
+<div class="gho-bottom-figure-row__figures">
+{%- for item in items -%}
+  <div class="gho-bottom-figure-row__figure">
+  {{ item.content }}
+  </div>
+{%- endfor -%}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-credits--photo-gallery.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-credits--photo-gallery.html.twig
@@ -1,8 +1,7 @@
 {%
   set classes = [
     'field--name-field-credits',
-    'gho-photo-gallery__credits',
-    'credits',
+    'gho-caption__credits',
   ]
 %}
 {% spaceless %}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-dataset--bottom-figure-row.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-dataset--bottom-figure-row.html.twig
@@ -1,0 +1,5 @@
+<div class="gho-bottom-figure-row__source">
+{%- for item in items -%}
+  {{ item.content }}
+{%- endfor -%}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-location--photo-gallery.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-location--photo-gallery.html.twig
@@ -1,8 +1,7 @@
 {%
   set classes = [
     'field--name-field-location',
-    'gho-photo-gallery__location',
-    'location',
+    'gho-caption__location',
   ]
 %}
 <p{{ attributes.addClass(classes) }}>

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-text--section-index.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-text--section-index.html.twig
@@ -1,0 +1,5 @@
+<div class="gho-section-index__description">
+{%- for item in items -%}
+  {{ item.content }}
+{%- endfor -%}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/media/media--author.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/media/media--author.html.twig
@@ -1,0 +1,36 @@
+{#
+/**
+ * @file
+ * Theme override to display an author media item.
+ *
+ * Change the `article` markup to `div` as it doesn't make so much semantic
+ * sense.
+ *
+ * Available variables:
+ * - name: Name of the media.
+ * - content: Media content.
+ *
+ * @see template_preprocess_media()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'media',
+    'media--type-' ~ media.bundle()|clean_class,
+    not media.isPublished() ? 'media--unpublished',
+    view_mode ? 'media--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_suffix.contextual_links }}
+  {% if content %}
+    <div class="gho-author__image">
+      {{ content.field_media_image }}
+    </div>
+    <div class="gho-author__content">
+    {{ content|without('field_media_image') }}
+    </div>
+  {% endif %}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--full.html.twig
@@ -77,8 +77,14 @@
  */
 #}
 {{ attach_library('common_design_subtheme/gho-article') }}
+{{ attach_library('common_design_subtheme/gho-caption') }}
+{# Pre-render hero so we can check for its existence when assigning classes. #}
 {%
   set hero_image = content.field_hero_image|render
+%}
+{# Pre-render the local_tasks so the `if local_tasks` below can work. #}
+{%
+  set local_tasks = local_tasks ? local_tasks|render
 %}
 {%
   set classes = [
@@ -89,7 +95,7 @@
     not node.isPublished() ? 'node--unpublished',
     view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
     'gho-article',
-    hero_image ? 'gho-article--with-hero-image',
+    hero_image ? 'gho-article--hero' : 'gho-article--no-hero',
     'clearfix',
   ]
 %}
@@ -104,7 +110,7 @@
   {% if local_tasks %}
   <div class="gho-article__local_tasks clearfix">{{ local_tasks }}</div>
   {% endif %}
-  <div{{ content_attributes.addClass('node__content') }}>
+  <div{{ content_attributes.addClass('node__content').addClass('gho-article__content') }}>
     {{ content|without(['field_hero_image', 'field_section']) }}
   </div>
 </article>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--home-page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--home-page.html.twig
@@ -73,7 +73,14 @@
  */
 #}
 {{ attach_library('common_design_subtheme/gho-bleed') }}
+{# Bonus: this will allow to have the caption applied for any sub-article,
+  photo galleries, stories etc. #}
+{{ attach_library('common_design_subtheme/gho-caption') }}
 {{ attach_library('common_design_subtheme/gho-home-page') }}
+{# Pre-render the local_tasks so the `if local_tasks` below can work. #}
+{%
+  set local_tasks = local_tasks ? local_tasks|render
+%}
 {%
   set classes = [
     'node',
@@ -101,7 +108,7 @@
   </header>
 
   {% if local_tasks %}
-  <div class="gho-story__local_tasks clearfix">{{ local_tasks }}</div>
+  <div class="gho-home-page__local_tasks clearfix">{{ local_tasks }}</div>
   {% endif %}
 
   {#
@@ -109,7 +116,7 @@
     content in the language of the homepage is enabled.
   #}
   {% if node.isPromoted() %}
-  <div{{ content_attributes.addClass('node__content') }}>
+  <div{{ content_attributes.addClass('node__content').addClass('gho-home-page__content') }}>
     {#
       In case we output any more content, exclude the fields we're giving
       special treatment.

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--sub-article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--sub-article.html.twig
@@ -85,17 +85,19 @@
     not node.isPublished() ? 'node--unpublished',
     view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
     'gho-sub-article',
-    hero_image ? 'gho-sub-article--with-hero-image',
+    hero_image ? 'gho-sub-article--hero' : 'gho-sub-article--no-hero',
     'clearfix',
   ]
 %}
 <article{{ attributes.addClass(classes) }}>
   <header class="gho-sub-article__header">
     {{ hero_image }}
-    <h2{{ title_attributes.addClass('gho-sub-article__title') }}>{{ label }}</h2>
-    {{ content.field_appeals }}
+    <div class="gho-sub-article__heading">
+      <h2{{ title_attributes.addClass('gho-sub-article__title') }}>{{ label }}</h2>
+      {{ content.field_appeals }}
+    </div>
   </header>
-  <div{{ content_attributes.addClass('node__content') }}>
+  <div{{ content_attributes.addClass('node__content').addClass('gho-sub-article__content') }}>
     {{ content|without(['field_hero_image', 'field_appeals']) }}
   </div>
 </article>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--story--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--story--full.html.twig
@@ -76,7 +76,12 @@
  *   in different view modes.
  */
 #}
+{{ attach_library('common_design_subtheme/gho-caption') }}
 {{ attach_library('common_design_subtheme/gho-story') }}
+{# Pre-render the local_tasks so the `if local_tasks` below can work. #}
+{%
+  set local_tasks = local_tasks ? local_tasks|render
+%}
 {%
   set classes = [
     'node',
@@ -97,11 +102,13 @@
   {% if local_tasks %}
   <div class="gho-story__local_tasks clearfix">{{ local_tasks }}</div>
   {% endif %}
-  <div{{ content_attributes.addClass('node__content') }}>
+  <div{{ content_attributes.addClass('node__content').addClass('gho-story__content') }}>
     {{ content.field_media }}
-    <div class="gho-story__caption caption">
-      {{ content.field_text }}
-      <span class="gho-story__credits credits">{{ content.credits }}</span>
+    <div class="gho-story__caption gho-caption gho-caption--formatted">
+      <div class="gho-caption__text">
+        {{ content.field_text }}
+        <span class="gho-caption__credits">{{ content.credits }}</span>
+      </div>
     </div>
     {{ content|without(['field_type', 'field_media', 'field_text', 'credits']) }}
   </div>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--story--teaser.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--story--teaser.html.twig
@@ -72,6 +72,7 @@
  *   in different view modes.
  */
 #}
+{{ attach_library('common_design_subtheme/gho-caption') }}
 {{ attach_library('common_design_subtheme/gho-story') }}
 {%
   set classes = [
@@ -91,11 +92,13 @@
     <h2{{ title_attributes.addClass('gho-aside__title') }}>{{ label }}</h2>
   </header>
 
-  <div{{ content_attributes.addClass('node__content') }}>
+  <div{{ content_attributes.addClass('node__content').addClass('gho-story__content') }}>
     {{ content.field_media }}
-    <div class="gho-story__caption caption">
-      {{ content.field_text }}
-      <span class="gho-story__credits credits">{{ content.credits }}</span>
+    <div class="gho-story__caption gho-caption gho-caption--formatted">
+      <div class="gho-caption__text">
+        {{ content.field_text }}
+        <span class="gho-caption__credits">{{ content.credits }}</span>
+      </div>
     </div>
     {{ content|without(['field_type', 'field_media', 'field_text', 'credits']) }}
   </div>

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--facts-and-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--facts-and-figures.html.twig
@@ -52,7 +52,7 @@
     view_mode ? 'gho-facts-and-figures--' ~ view_mode|clean_class,
     'gho-aside',
     'gho-aside--dark',
-    'gho-bleed',
+    'gho-bleed--background-only',
   ]
 %}
 {% block paragraph %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--image-with-text--facts-and-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--image-with-text--facts-and-figures.html.twig
@@ -40,6 +40,7 @@
  * @ingroup themeable
  */
 #}
+{{ attach_library('common_design_subtheme/gho-caption') }}
 {%
   set classes = [
     'paragraph',
@@ -52,9 +53,11 @@
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
     {{ content.field_image }}
-    <div class="gho-facts-and-figures__caption caption">
-      {{ content.field_text }}
-      <span class="gho-facts-and-figures__credits credits">{{ content.credits }}</span>
+    <div class="gho-facts-and-figures__caption gho-caption gho-caption--formatted">
+      <div class="gho-caption__text">
+        {{ content.field_text }}
+        <span class="gho-caption__credits">{{ content.credits }}</span>
+      </div>
     </div>
     {{ content|without(['field_image', 'field_text', 'credits']) }}
     {% endblock %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--interactive-content.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--interactive-content.html.twig
@@ -55,7 +55,7 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-      <header class="gho-interactive-content__header">
+      <header class="gho-interactive-content__header visually-hidden">
         <span class="gho-aside__pre-title">{{- content.field_type -}}</span>
         <h2 class="gho-aside__title">{{- content.field_title -}}</h2>
       </header>

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--photo-gallery.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--photo-gallery.html.twig
@@ -56,11 +56,14 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-      {{ content|without(['field_caption', 'field_credits']) }}
-      <p class="field--name-field-caption gho-photo-gallery__caption caption">
-        {{ content.field_caption }}
-        {{ content.field_credits }}
-      </p>
+      {{ content|without(['field_location', 'field_caption', 'field_credits']) }}
+      <div class="gho-photo-gallery__caption gho-caption">
+        {{ content.field_location }}
+        <p class="field--name-field-caption gho-caption__text">
+          {{ content.field_caption }}
+          {{ content.field_credits }}
+        </p>
+      </div>
     {% endblock %}
   </div>
 {% endblock paragraph %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--story.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--story.html.twig
@@ -41,12 +41,14 @@
  */
 #}
 {{ attach_library('common_design_subtheme/gho-aside') }}
+{{ attach_library('common_design_subtheme/gho-story') }}
 {%
   set classes = [
     'paragraph',
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-story-paragraph',
     'gho-aside',
     'gho-aside--dark',
     'gho-bleed--background-only',

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--sub-article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--sub-article.html.twig
@@ -1,0 +1,59 @@
+{#
+/**
+ * @file
+ * Theme implementation for a sub-article paragraph.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.a
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-sub-article') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-sub-article-paragraph',
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--text.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--text.html.twig
@@ -47,6 +47,7 @@
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-text',
   ]
 %}
 {% block paragraph %}


### PR DESCRIPTION
Ticket: GHO-59, GHO-61, GHO-62, GHO-65, GHO-78

This PR deals with several visual adjustments (mostly vertical margins: GHO-59, typography: GHO-61) for most of the components.

I tried initially to create individual PRs but it was a mess to do as many of the changes are dependent on each others. Each commit deals with a separate component though to try to ease the review.

Some of the main changes:

**`gho-caption` component**

A `gho-caption` css component was introduced and  all the places using the caption styling have been consolidated.

**Content width**

Though the PDF with the horizontal alignement is daunting, it's actually pretty simple: the main content area has a max-width of 904px and is centered. The only place that need something special is the white box above the hero image where its background "bleeds" to 1040px. This is handled in https://github.com/UN-OCHA/gho-site/commit/c52fbd316d843a90bae4074b983c4a8e16072f40

**Vertical margins**

I've adjusted most vertical margins according to the latest specs. I've been using margin-top on the top containers (paragraph div etc.)  where possible for consistency and because it's easier to handle sub-articles so we don't have to take into account the margin bottom of the latest element of a sub-article which would conflict with the top margin of the next element after the sub-article paragraph.

This still needs another pass to confirm everything is as intended, notably after creating different layouts (sub-article followed by story, interactive followed by further reading etc.)

**Typography**

All the typography have been reviewed (footnotes still WIP) aside of the homepage banner that needs discussion. Still need to set the default color to `#1f1f1f` for the main content.


