### PR TITLE
[GHO-59][GHO-61] Adjust footnotes

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-footnotes/gho-footnotes.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-footnotes/gho-footnotes.css
@@ -1,17 +1,25 @@
 .gho-footnote-list {
-  margin: 2rem 0;
-  padding: 2rem 0 0 0;
-  border-top: 1px solid #ccc;
+  margin: 6.75rem 0 0 0;
 }
 .gho-footnote-list__title {
-  margin: 0 0 0.5rem 0;
-  color: black;
+  margin: 0 0 1.5rem 0;
+  padding: 0 0 1.5rem 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1f1f1f;
+  border-bottom: 1px solid #ccc;
+}
+@media (min-width: 1024px) {
+  .gho-footnote-list__title {
+    font-size: 1.5rem;
+  }
 }
 .gho-footnote-list__list {
   max-width: var(--reading-width);
   margin: 0;
-  padding: 0.5rem 1.5rem;
-  font-size: 0.85rem;
+  padding: 0 1.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
 }
 /* @todo check if it's also fine to decorate the number like that in Arabic. */
 .gho-footnote-reference span:before {
@@ -20,14 +28,11 @@
 .gho-footnote-reference span:after {
   content: "]";
 }
-.gho-footnote {
-  line-height: 1.2;
-}
 .gho-footnote:target {
   background-color: #eee;
 }
 .gho-footnote + .gho-footnote {
-  margin-top: 0.5rem;
+  margin-top: 0.375rem;
 }
 .gho-footnote__backlinks {
   display: inline;
@@ -48,28 +53,28 @@
   /**
    * Ok,so we don't specify a left property so that the list stays at its
    * current position aligned to the left of the content area. Then we translate
-   * it to the maximum margin of the body (1400px - 1140px) / 2 and limiting its
-   * width to 1400px. We add a padding left of 130px to compensate and to ensure
-   * it always spans to the right border of the body we add 130px to the width
+   * it to the maximum margin of the body (1400px - 904px) / 2 and limiting its
+   * width to 1400px. We add a padding left of 248px to compensate and to ensure
+   * it always spans to the right border of the body we add 248px to the width
    * and now we have a list going from left to right of the body, aligned with
    * the content and fixed to the bottom.
    * Oh yeah! Nothing better than some magical css soup.
    */
-  width: calc(100% + 130px);
+  width: calc(100% + 248px);
   max-width: 1400px;
   max-height: 50%;
-  transform: translateX(-130px);
-  padding: 0.5rem 0 0.5rem 130px;
+  transform: translateX(-248px);
+  padding: 1rem 0 1rem 248px;
   margin: 0;
-  background: white;
+  background: #fff;
   border-top: 1px solid #ccc;
   overflow-x: hidden;
   overflow-y: auto;
   z-index: 100;
 }
 [dir="rtl"] .gho-footnote-list__wrapper[data-visible] {
-  transform: translateX(130px);
-  padding: 0.5rem 130px 0.5rem 0;
+  transform: translateX(248px);
+  padding: 1rem 248px 1rem 0;
 }
 /* Visually hidden to perserve the numbering and keep the footnotes and their
  * backlinks in the accessiblity tree. */
@@ -86,5 +91,5 @@
   margin-top: 0;
 }
 .gho-footnote-list__wrapper[data-visible] .gho-footnote[data-visible] + .gho-footnote[data-visible] {
-  margin-top: 0.5rem;
+  margin-top: 0.375rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-further-reading/gho-further-reading.css
@@ -11,15 +11,14 @@
  * Title
  */
 .gho-further-reading__title {
-  margin-bottom: 1.5rem;
+  margin: 0 0 1.5rem 0;
   font-size: 1.25rem;
+  font-weight: 700;
   color: #1f1f1f;
 }
 @media (min-width: 1024px) {
   .gho-further-reading__title {
-    margin-bottom: 1.5rem;
     font-size: 1.5rem;
-    font-weight: 700;
   }
 }
 


### PR DESCRIPTION
Ticket: GHO-59, GHO-61

This adjusts the styling of the references and fixes an issue with the "further reading" title as they are supposed to have the same appearance.

<img width="536" alt="Screen Shot 2020-11-16 at 18 52 36" src="https://user-images.githubusercontent.com/696348/99238630-5048da80-283d-11eb-9ec4-2c40573263a7.png">

This also adjusts the margins/translation etc. for the footnotes popup to stay attached to the left and right and work with the `904px` of the content area.

Note:  the backlinks `super` vertical align changes the spacing impression between the footnotes. I'll create a ticket for the backlinks because I think they want to change their design according to the prototype v4. Fine as it is for now.