### PR TITLE
[GHO-105] Adjust the separators to be full or half of the width of the reading width

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-separator/gho-separator.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-separator/gho-separator.css
@@ -1,14 +1,21 @@
 .separator {
   border: none;
+  width: 100%;
+  height: 1px;
+  max-width: var(--reading-width);
+  margin: 2rem 0;
+}
+.separator::before {
+  content: "";
+  display: block;
+  width: 100%;
   height: 1px;
   background: #ccc;
-  margin: 2rem auto;
+  margin: 0 auto;
 }
-
-.separator--half {
+.separator--half::before {
   width: 50%;
 }
-
-.separator--full {
+.separator--full::before {
   width: 100%;
 }


### PR DESCRIPTION
Ticket: GHO-105

This adjusts the separator to be full width or half width of the `reading width` (720px). I'm wondering if that's correct or if we want to be relative to the `content width` (904px). 