### PR TITLE
[GHO-62] Add bottom border to author component

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-author/gho-author.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-author/gho-author.css
@@ -1,6 +1,14 @@
 /**
  * Base Author field
  */
+/* The border is not on the container itself due to eventual left/right padding
+ * values that can interfere. Ex: when it has the `content-width` class. */
+.gho-author::after {
+  content: "";
+  display: block;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid #d8d8d8;
+}
 .gho-author .media {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Ticket: GHO-62

This depends on #119 being merged.

This adds a border bottom to the author component to look like:

<img width="573" alt="Screen Shot 2020-11-19 at 19 13 47" src="https://user-images.githubusercontent.com/696348/99652617-605df580-2a9b-11eb-80bc-e90638015d0e.png">

