### PR TITLE
[GHO-111] ensure negative margins are enforced separately from content-width

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-paragraphs--facts-and-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-paragraphs--facts-and-figures.html.twig
@@ -1,7 +1,9 @@
-<div class="gho-facts-and-figures__list content-width">
-{%- for item in items -%}
-  <div class="gho-facts-and-figures__item">
-  {{ item.content }}
+<div class="content-width">
+  <div class="gho-facts-and-figures__list">
+  {%- for item in items -%}
+    <div class="gho-facts-and-figures__item">
+    {{ item.content }}
+    </div>
+  {%- endfor -%}
   </div>
-{%- endfor -%}
 </div>


### PR DESCRIPTION
# GHO-111

Small fixup to get our styles (which were correct to begin with) applying cleanly within the `.content-width` container class.