### PR TITLE
[GHO-121] Always use dark grey for highlight style

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-text/gho-text.css
@@ -13,6 +13,7 @@
   max-width: var(--reading-width);
 }
 .gho-text p.highlight {
+  color: #1f1f1f;
   font-size: 1.25rem;
   font-weight: 700;
   line-height: 2rem;


### PR DESCRIPTION
Ticket: GHO-121

Another short PR. 

**Note**: This results in having blockquotes with the highlight style applied to look like other paragraphs with this style, so let's wait for confirmation before merging.