### PR TITLE
[GHO-126] Fix datawrapper iframe ID

### DIFF
--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoDatawrapperFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoDatawrapperFormatter.php
@@ -68,7 +68,7 @@ class GhoDatawrapperFormatter extends FormatterBase {
     if ($iframe->hasAttribute('id')) {
       $id = preg_replace('/^datawrapper-chart-/', '', $iframe->getAttribute('id'));
       if (!empty($id)) {
-        $attributes['id'] = $id;
+        $attributes['id'] = 'datawrapper-chart-' . $id;
       }
     }
 


### PR DESCRIPTION
Ticket: GHO-126

Minor change to restore the ID prefix for the datawrapper iframes. That doesn't have any impact but it's cleaner.