### PR TITLE
[GHO-154] Adjust number formatting for Needs and Requirements

### DIFF
--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoNumberFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoNumberFormatter.php
@@ -373,6 +373,9 @@ class GhoNumberFormatter extends FormatterBase {
     if ($number < 1000) {
       return $number;
     }
+    elseif ($number < 10000) {
+      return $this->formatNumberDecimal($number, $langcode);
+    }
     elseif ($number >= 1e15) {
       return $this->formatNumberDecimal($number, $langcode);
     }
@@ -393,6 +396,16 @@ class GhoNumberFormatter extends FormatterBase {
     $n = abs($number);
     $p = floor(($n ? log($n) : 0) / log(1000));
     $n = $n / pow(1000, $p);
+
+    // GHO-152: Use the "million" for number below 1 million.
+    if ($number < 1e6) {
+      $n = $n / 1000;
+      $p = $p + 1;
+      $precision = 2;
+    }
+    else {
+      $precision = 1;
+    }
 
     // Retrieve the pattern key for the number (ex: 1000000). Skip if Undefined.
     $key = (string) pow(1000, $p);


### PR DESCRIPTION
Ticket: GHO-154

- Number > 1,000,000 => precision 1 (ex: 12.3 million, 8.7 billion)
- Number > 10,000 and < 1,000,000 => precision 2, use "million" (ex: 0.54 million, 0.02 million)
- Number > 1,000 and < 10,000 => formatted with thousand separator (depends on language): (ex: 2,345)
- Number < 1,000 => raw number (ex: 678)

<img width="970" alt="Screen Shot 2020-11-27 at 15 59 06" src="https://user-images.githubusercontent.com/696348/100421796-6885e880-30cc-11eb-92e1-f5b3ff424948.png">
<img width="973" alt="Screen Shot 2020-11-27 at 15 59 12" src="https://user-images.githubusercontent.com/696348/100421798-6ae84280-30cc-11eb-9b0a-92685dd3d2fd.png">
<img width="946" alt="Screen Shot 2020-11-27 at 15 59 23" src="https://user-images.githubusercontent.com/696348/100421801-6c196f80-30cc-11eb-8051-cca447b79763.png">
