### PR TITLE
[GHO-158] Handle Needs and Requirements TBC values

### DIFF
--- a/config/field.field.taxonomy_term.needs_and_requirements.field_people_in_need.yml
+++ b/config/field.field.taxonomy_term.needs_and_requirements.field_people_in_need.yml
@@ -12,7 +12,7 @@ field_name: field_people_in_need
 entity_type: taxonomy_term
 bundle: needs_and_requirements
 label: 'People in need'
-description: ''
+description: 'Enter `0` to indicate TBC.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/field.field.taxonomy_term.needs_and_requirements.field_people_targeted.yml
+++ b/config/field.field.taxonomy_term.needs_and_requirements.field_people_targeted.yml
@@ -12,7 +12,7 @@ field_name: field_people_targeted
 entity_type: taxonomy_term
 bundle: needs_and_requirements
 label: 'People targeted'
-description: ''
+description: 'Enter `0` to indicate TBC.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/field.field.taxonomy_term.needs_and_requirements.field_requirements.yml
+++ b/config/field.field.taxonomy_term.needs_and_requirements.field_requirements.yml
@@ -12,7 +12,7 @@ field_name: field_requirements
 entity_type: taxonomy_term
 bundle: needs_and_requirements
 label: 'Requirements (US$)'
-description: ''
+description: 'Enter `0` to indicate TBC.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/views.view.needs_and_requirements.yml
+++ b/config/views.view.needs_and_requirements.yml
@@ -241,9 +241,9 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: TBC
           hide_empty: false
-          empty_zero: false
+          empty_zero: true
           hide_alter_empty: true
           click_sort_column: value
           type: bigint_item_default
@@ -305,9 +305,9 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: TBC
           hide_empty: false
-          empty_zero: false
+          empty_zero: true
           hide_alter_empty: true
           click_sort_column: value
           type: bigint_item_default
@@ -369,9 +369,9 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: TBC
           hide_empty: false
-          empty_zero: false
+          empty_zero: true
           hide_alter_empty: true
           click_sort_column: value
           type: bigint_item_default

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoNumberFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoNumberFormatter.php
@@ -370,7 +370,10 @@ class GhoNumberFormatter extends FormatterBase {
    * @see http://st.unicode.org/cldr-apps/v#/fr/Compact_Decimal_Formatting
    */
   public function formatNumberCompact($number, $langcode, $type = 'long', $precision = 2) {
-    if ($number < 1000) {
+    if ($number <= 0) {
+      return '-';
+    }
+    elseif ($number < 1000) {
       return $number;
     }
     elseif ($number < 10000) {

--- a/html/modules/custom/gho_figures/src/Form/GhoFiguresImportNeedsAndRequirementsFiguresForm.php
+++ b/html/modules/custom/gho_figures/src/Form/GhoFiguresImportNeedsAndRequirementsFiguresForm.php
@@ -237,6 +237,7 @@ class GhoFiguresImportNeedsAndRequirementsFiguresForm extends FormBase {
             </ol>
           </li>
           <li>Make sure all the figures are non formatted numbers (ex: 1200000 not 1.2 million)</li>
+          <li>Use 0, -1, - or TBC to indicate a missing value</li>
         </ul>
       '),
     ];
@@ -1081,8 +1082,14 @@ class GhoFiguresImportNeedsAndRequirementsFiguresForm extends FormBase {
    */
   public static function preprocessNumber($name, array &$data) {
     if (isset($data[$name])) {
-      $options = ['options' => ['min_range' => 0]];
-      $value = filter_var($data[$name], FILTER_VALIDATE_INT, $options);
+      $value = $data[$name];
+      if ($value <= 0 || $value === '-' || strtoupper($value) === 'TBC') {
+        $value = 0;
+      }
+      else {
+        $options = ['options' => ['min_range' => 0]];
+        $value = filter_var($data[$name], FILTER_VALIDATE_INT, $options);
+      }
       // Remove the value if it's not a positive integer so that the row
       // will be removed and an error displayed.
       if ($value === FALSE) {
@@ -1111,6 +1118,9 @@ class GhoFiguresImportNeedsAndRequirementsFiguresForm extends FormBase {
   public static function displayNumber($name, array $data) {
     if (!isset($data[$name])) {
       return '';
+    }
+    if ($data[$name] == 0) {
+      return 'TBC';
     }
     // @todo use the same formatter as the one used to render the figures in
     // the frontend (ex: 1.2 million).


### PR DESCRIPTION
Ticket: GHO-158

This handles TBC values for Needs and Requirements. In the backend the values are stored as `0`.

`0` is displayed as `TBC` in the backend and importer overview to ease understanding and is displayed as `-` in NaR paragraphs so that translation is not needed (confirmed with Edgar).

Summary: `-1, 0, - or TBC` in spreadsheet -> stored as `0` -> displayed as `-`

## Testing

`drush cr`, `drush cim`, then import a spreadsheet (there is one attached to the ticket where Total as 2 TBC values), check the preview, then check the homepage after import it should show `-`.