### PR TITLE
[GHO-167] Homepage v3

### DIFF
--- a/config/core.entity_form_display.paragraph.article_list.default.yml
+++ b/config/core.entity_form_display.paragraph.article_list.default.yml
@@ -1,0 +1,34 @@
+uuid: 1c3a01a2-6468-4567-bb77-f2d64d8121eb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.article_list.field_links
+    - field.field.paragraph.article_list.field_title
+    - paragraphs.paragraphs_type.article_list
+  module:
+    - link
+id: paragraph.article_list.default
+targetEntityType: paragraph
+bundle: article_list
+mode: default
+content:
+  field_links:
+    weight: 1
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_form_display.paragraph.section_index.default.yml
+++ b/config/core.entity_form_display.paragraph.section_index.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.section_index.field_caption
+    - field.field.paragraph.section_index.field_image
     - field.field.paragraph.section_index.field_menu
     - field.field.paragraph.section_index.field_paragraphs
     - field.field.paragraph.section_index.field_section
@@ -11,7 +13,8 @@ dependencies:
     - paragraphs.paragraphs_type.section_index
   module:
     - allowed_formats
-    - gho_fields
+    - double_field
+    - media_library
     - paragraphs
     - text
 id: paragraph.section_index.default
@@ -19,21 +22,49 @@ targetEntityType: paragraph
 bundle: section_index
 mode: default
 content:
-  field_menu:
+  field_caption:
     weight: 3
-    settings: {  }
+    settings:
+      first:
+        type: textfield
+        label_display: block
+        size: 60
+        placeholder: 'Ex: Mbuji-Mayi, RDC'
+        label: Ok
+        cols: 10
+        rows: 5
+        prefix: ''
+        suffix: ''
+      second:
+        type: textarea
+        label_display: block
+        size: 10
+        placeholder: ''
+        label: Ok
+        cols: 10
+        rows: 5
+        prefix: ''
+        suffix: ''
+      inline: false
     third_party_settings: {  }
-    type: gho_menu_select
+    type: double_field
+    region: content
+  field_image:
+    weight: 2
+    settings:
+      media_types: {  }
+    third_party_settings: {  }
+    type: media_library_widget
     region: content
   field_paragraphs:
-    weight: 4
+    weight: 5
     settings:
       title: Paragraph
       title_plural: Paragraphs
       edit_mode: open
-      add_mode: dropdown
+      add_mode: button
       form_display_mode: default
-      default_paragraph_type: _none
+      default_paragraph_type: article_list
     third_party_settings: {  }
     type: entity_reference_paragraphs
     region: content
@@ -46,7 +77,7 @@ content:
     type: string_textfield
     region: content
   field_text:
-    weight: 2
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
@@ -66,4 +97,5 @@ content:
     region: content
 hidden:
   created: true
+  field_menu: true
   status: true

--- a/config/core.entity_view_display.paragraph.article_list.default.yml
+++ b/config/core.entity_view_display.paragraph.article_list.default.yml
@@ -1,0 +1,31 @@
+uuid: f8292919-324f-4546-83c7-e4aaca9a2c8b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.article_list.field_links
+    - field.field.paragraph.article_list.field_title
+    - paragraphs.paragraphs_type.article_list
+  module:
+    - gho_fields
+id: paragraph.article_list.default
+targetEntityType: paragraph
+bundle: article_list
+mode: default
+content:
+  field_links:
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: gho_article_list
+    region: content
+  field_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/config/core.entity_view_display.paragraph.section_index.default.yml
+++ b/config/core.entity_view_display.paragraph.section_index.default.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.section_index.field_caption
+    - field.field.paragraph.section_index.field_image
     - field.field.paragraph.section_index.field_menu
     - field.field.paragraph.section_index.field_paragraphs
     - field.field.paragraph.section_index.field_section
@@ -18,15 +20,24 @@ targetEntityType: paragraph
 bundle: section_index
 mode: default
 content:
-  field_menu:
-    weight: 4
+  field_caption:
+    weight: 3
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: gho_related_articles
+    type: gho_caption
+    region: content
+  field_image:
+    weight: 2
+    label: hidden
+    settings:
+      view_mode: hero_image
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
     region: content
   field_paragraphs:
-    weight: 3
+    weight: 5
     label: hidden
     settings:
       view_mode: default
@@ -43,7 +54,7 @@ content:
     type: string
     region: content
   field_text:
-    weight: 2
+    weight: 4
     label: hidden
     settings: {  }
     third_party_settings: {  }
@@ -57,4 +68,5 @@ content:
     third_party_settings: {  }
     type: string
     region: content
-hidden: {  }
+hidden:
+  field_menu: true

--- a/config/field.field.paragraph.article_list.field_links.yml
+++ b/config/field.field.paragraph.article_list.field_links.yml
@@ -1,0 +1,23 @@
+uuid: 1843964e-872c-4c84-a0df-9e538151b472
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_links
+    - paragraphs.paragraphs_type.article_list
+  module:
+    - link
+id: paragraph.article_list.field_links
+field_name: field_links
+entity_type: paragraph
+bundle: article_list
+label: Articles
+description: 'List of articles. Type the title of an article to select it.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 1
+  title: 0
+field_type: link

--- a/config/field.field.paragraph.article_list.field_title.yml
+++ b/config/field.field.paragraph.article_list.field_title.yml
@@ -1,0 +1,19 @@
+uuid: 861c4481-cf2e-4480-9a6d-d04ac715fde8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.article_list
+id: paragraph.article_list.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: article_list
+label: Title
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.section_index.field_caption.yml
+++ b/config/field.field.paragraph.section_index.field_caption.yml
@@ -1,0 +1,39 @@
+uuid: b8c679af-1f91-4490-acf0-3f0acc0039d0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_caption
+    - paragraphs.paragraphs_type.section_index
+  module:
+    - double_field
+id: paragraph.section_index.field_caption
+field_name: field_caption
+entity_type: paragraph
+bundle: section_index
+label: Caption
+description: 'Caption that will be displayed below the title. It should contain a <strong>location</strong> in the form <em>Location, Country</em>. Ex: <em>Mbuji-Mayi, RDC</em> and a <strong>text</strong>. Credits for the hero image will be automatically added to the end when displayed.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  first:
+    label: Location
+    required: true
+    list: false
+    allowed_values: {  }
+    max: null
+    min: null
+    on_label: 'On'
+    off_label: 'Off'
+  second:
+    label: Text
+    required: true
+    list: false
+    allowed_values: {  }
+    max: null
+    min: null
+    on_label: 'On'
+    off_label: 'Off'
+field_type: double_field

--- a/config/field.field.paragraph.section_index.field_image.yml
+++ b/config/field.field.paragraph.section_index.field_image.yml
@@ -1,0 +1,28 @@
+uuid: e53f1508-b8ac-4b1b-b887-c7fcf792eb70
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_image
+    - media.type.image
+    - paragraphs.paragraphs_type.section_index
+id: paragraph.section_index.field_image
+field_name: field_image
+entity_type: paragraph
+bundle: section_index
+label: Image
+description: 'Hero image for the section index.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.paragraph.section_index.field_paragraphs.yml
+++ b/config/field.field.paragraph.section_index.field_paragraphs.yml
@@ -4,10 +4,8 @@ status: true
 dependencies:
   config:
     - field.storage.paragraph.field_paragraphs
-    - paragraphs.paragraphs_type.interactive_content
-    - paragraphs.paragraphs_type.photo_gallery
+    - paragraphs.paragraphs_type.article_list
     - paragraphs.paragraphs_type.section_index
-    - paragraphs.paragraphs_type.text
   module:
     - entity_reference_revisions
 id: paragraph.section_index.field_paragraphs
@@ -15,8 +13,8 @@ field_name: field_paragraphs
 entity_type: paragraph
 bundle: section_index
 label: Paragraphs
-description: 'Extra content like a text, a photo gallery or an interactive content.'
-required: false
+description: 'List of articles.'
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
@@ -25,10 +23,14 @@ settings:
   handler_settings:
     negate: 0
     target_bundles:
-      interactive_content: interactive_content
-      photo_gallery: photo_gallery
-      text: text
+      article_list: article_list
     target_bundles_drag_drop:
+      achievement:
+        weight: 18
+        enabled: false
+      article_list:
+        enabled: true
+        weight: 17
       bottom_figure_row:
         weight: 15
         enabled: false
@@ -42,8 +44,8 @@ settings:
         weight: 18
         enabled: false
       interactive_content:
-        enabled: true
         weight: 19
+        enabled: false
       layout:
         weight: 20
         enabled: false
@@ -51,8 +53,8 @@ settings:
         weight: 21
         enabled: false
       photo_gallery:
-        enabled: true
         weight: 22
+        enabled: false
       section_index:
         weight: 23
         enabled: false
@@ -69,6 +71,6 @@ settings:
         weight: 27
         enabled: false
       text:
-        enabled: true
         weight: 28
+        enabled: false
 field_type: entity_reference_revisions

--- a/config/field.storage.paragraph.field_caption.yml
+++ b/config/field.storage.paragraph.field_caption.yml
@@ -1,0 +1,32 @@
+uuid: a5431e26-4719-4734-aecb-95b3ff0ebbf9
+langcode: en
+status: true
+dependencies:
+  module:
+    - double_field
+    - paragraphs
+id: paragraph.field_caption
+field_name: field_caption
+entity_type: paragraph
+type: double_field
+settings:
+  storage:
+    first:
+      type: string
+      maxlength: 255
+      precision: 10
+      scale: 2
+      datetime_type: datetime
+    second:
+      type: text
+      maxlength: 255
+      precision: 10
+      scale: 2
+      datetime_type: datetime
+module: double_field
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.article_list.yml
+++ b/config/paragraphs.paragraphs_type.article_list.yml
@@ -1,0 +1,10 @@
+uuid: 9a3a9b88-c7cc-438f-a641-853ad6a391f8
+langcode: en
+status: true
+dependencies: {  }
+id: article_list
+label: 'Article list'
+icon_uuid: null
+icon_default: null
+description: 'A list of links to articles with an optional title.'
+behavior_plugins: {  }

--- a/html/modules/custom/gho_fields/config/schema/gho_fields.schema.yml
+++ b/html/modules/custom/gho_fields/config/schema/gho_fields.schema.yml
@@ -1,4 +1,9 @@
 # Formatters.
+field.formatter.settings.gho_article_list:
+  type: mapping
+  label: 'GHO article list formatter settings'
+  mapping:
+    # No settings.
 field.formatter.settings.gho_caption:
   type: mapping
   label: 'GHO caption formatter settings'

--- a/html/modules/custom/gho_fields/gho_fields.module
+++ b/html/modules/custom/gho_fields/gho_fields.module
@@ -59,6 +59,11 @@ function gho_fields_theme() {
     'gho_figures_formatter__small' => [
       'base hook' => 'gho_figures_formatter',
     ],
+    'gho_article_list_formatter' => [
+      'variables' => [
+        'links' => NULL,
+      ],
+    ],
   ];
 }
 

--- a/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoArticleListFormatter.php
+++ b/html/modules/custom/gho_fields/src/Plugin/Field/FieldFormatter/GhoArticleListFormatter.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Drupal\gho_fields\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'gho_article_list' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "gho_article_list",
+ *   label = @Translation("GHO article list"),
+ *   field_types = {
+ *     "link"
+ *   }
+ * )
+ */
+class GhoArticleListFormatter extends FormatterBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * Constructs a FormatterBase object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager, LanguageManagerInterface $language_manager) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+
+    $this->entityTypeManager = $entity_type_manager;
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('entity_type.manager'),
+      $container->get('language_manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+    $links = [];
+
+    $storage = $this->entityTypeManager->getStorage('node');
+    $langcode = $this->languageManager->getCurrentLanguage()->getId();
+
+    // Retrieve the node links.
+    foreach ($items as $item) {
+      $url = $item->getUrl();
+      if (!$url->isRouted()) {
+        continue;
+      }
+      $parameters = $url->getRouteParameters();
+      $entity_type = key($parameters);
+      if ($entity_type !== 'node') {
+        continue;
+      }
+      $entity_id = $parameters[$entity_type];
+      if (empty($entity_id)) {
+        continue;
+      }
+      $entity_ids[$entity_id] = $url;
+    }
+
+    // Generate links for the nodes that are published and accessible.
+    if (isset($entity_type) && !empty($entity_ids)) {
+      $ids = $storage
+        ->getQuery()
+        ->condition('nid', array_keys($entity_ids), 'IN')
+        ->condition('status', NodeInterface::PUBLISHED)
+        ->condition('langcode', $langcode)
+        ->accessCheck(TRUE)
+        ->execute();
+
+      if (!empty($ids)) {
+        $nodes = $storage->loadMultiple($ids);
+
+        foreach ($entity_ids as $id => $url) {
+          if (isset($nodes[$id])) {
+            $links[] = [
+              'url' => $url,
+              'title' => $nodes[$id]->title->value,
+            ];
+          }
+        }
+      }
+    }
+    if (!empty($links)) {
+      $element = [
+        '#theme' => 'gho_article_list_formatter',
+        '#links' => $links,
+      ];
+    }
+
+    return $element;
+  }
+
+}

--- a/html/modules/custom/gho_fields/templates/gho-article-list-formatter.html.twig
+++ b/html/modules/custom/gho_fields/templates/gho-article-list-formatter.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a GHO article list formatter.
+ *
+ * Available variables:
+ * - links: list of links to articles.
+ *
+ * @ingroup themeable
+ */
+#}
+{% if links %}
+<ul class="gho-article-list__list">
+{% for link in links %}
+  {% spaceless %}
+  <li class="gho-article-list__list__item">
+    <a href="{{ link.url }}" class="gho-article-list-link">
+      <span class="gho-article-list-link__title">{{ link.title }}</span>
+      <svg class="cd-icon cd-icon--arrow-right gho-article-list-link__arrow" width="16" height="16" aria-hidden="true" focusable="false">
+        <use xlink:href="#cd-icon--arrow-right"></use>
+      </svg>
+    </a>
+  </li>
+  {% endspaceless %}
+{% endfor %}
+</ul>
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -141,3 +141,8 @@ gho-achievement:
   css:
     theme:
       components/gho-achievement/gho-achievement.css: {}
+
+gho-article-list:
+  css:
+    theme:
+      components/gho-article-list/gho-article-list.css: {}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -272,6 +272,18 @@ function common_design_subtheme_preprocess_paragraph__image_with_text(&$variable
 }
 
 /**
+ * Implements hook_preprocess_paragraph__section_index().
+ *
+ * Extract the media credits to display them after the text.
+ */
+function common_design_subtheme_preprocess_paragraph__section_index(&$variables) {
+  if (isset($variables['content']['field_image'][0]['#media'])) {
+    $credits = $variables['content']['field_image'][0]['#media']->field_credits->value;
+    $variables['content']['field_caption'][0]['#credits'] = ['#markup' => $credits];
+  }
+}
+
+/**
  * Implements hook_preprocess_field__node__field_caption__article().
  *
  * Add a class to identify the article caption.

--- a/html/themes/custom/common_design_subtheme/components/gho-article-list/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-list/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Article list list
+===================================================
+
+List of article links for the secion index paragraphs on the homepage.

--- a/html/themes/custom/common_design_subtheme/components/gho-article-list/gho-article-list.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-list/gho-article-list.css
@@ -1,0 +1,59 @@
+.gho-article-list {
+  margin-top: 4.5rem;
+}
+
+.gho-article-list__title {
+  margin: 0 0 1.5rem 0;
+  color: #1f1f1f;
+  font-size: 1.3125rem;
+  font-weight: 700;
+  line-height: 1.5rem;
+}
+
+.gho-article-list__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.gho-article-list__list__item {
+  margin: 0;
+  padding: 0;
+  border: 1px solid #d8d8d8;
+  border-width: 1px 0 1px 0;
+}
+.gho-article-list__list__item + .gho-article-list__list__item {
+  border-width: 0 0 1px 0;
+}
+
+.gho-article-list-link {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 1.5rem 0;
+  color: #1f1f1f;
+  text-decoration: none;
+}
+.gho-article-list-link:hover,
+.gho-article-list-link:focus,
+.gho-article-list-link:active  {
+  text-decoration: underline;
+}
+
+.gho-article-list-link__title {
+  flex: 1 1 auto;
+}
+
+.gho-article-list-link__arrow.cd-icon {
+  display: none; /* not visible on skinny screens */
+  width: 0.75rem;
+  height: 0.75rem;
+  margin: 0 0.25rem;
+  /* @todo should this be the same color as the links or use the UN blue? */
+  fill: #3a90d2; /* UN blue */
+}
+@media screen and (min-width: 576px) {
+  .gho-article-list-link__arrow.cd-icon {
+    display: block;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-article-list/gho-article-list.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-list/gho-article-list.css
@@ -57,3 +57,6 @@
     display: block;
   }
 }
+[dir='rtl'] .gho-article-list-link__arrow {
+  transform: scale(-1, 1);
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-section-index/gho-section-index.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-section-index/gho-section-index.css
@@ -1,29 +1,34 @@
 .gho-section-index {
   margin-top: 6.25rem;
-  padding-top: 2.25rem;
-  border-top: 1px solid #d8d8d8;
 }
 .gho-section-index + .gho-section-index {
-  /* This is to be closer to what is in the design documents as none of the
-   * specs documents contain indication of what should be the spacing between
-   * section areas. This corresponds to the section index margin-top (6.25rem) +
-   * the padding of the related articles (2rem). */
-  margin-top: 8.25rem;
-  padding-top: 0;
-  border-top: none;
+  margin-top: 9rem;
 }
+.gho-section-index:last-of-type {
+  margin-bottom: 7rem; /* 9rem - 2rem from the padding bottom of the main... */
+}
+
 /* This is similar to the sub-article styling */
 .gho-section-index__header {
+  position: relative;
   margin-bottom: 1rem;
+}
+.gho-section-index__heading {
+  position: absolute;
+  max-width: var(--reading-width);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
 }
 .gho-section-index__pre-title {
   display: block;
   margin-bottom: 0.6rem;
-  font-size: 0.6rem;
-  font-weight: bold;
-  line-height: 0.6rem;
+  font-size: 0.875rem;
+  font-weight: 700;
+  line-height: 0.875rem;
   letter-spacing: 0.05rem;
-  color: #707070;
+  color: #fff;
 }
 .gho-section-index__title {
   margin: 0;
@@ -31,7 +36,7 @@
   font-size: 1.625rem;
   font-weight: 700;
   line-height: 1.75rem;
-  color: #1f1f1f;
+  color: #fff;
 }
 @media (min-width: 768px) {
   .gho-section-index__title {
@@ -41,12 +46,24 @@
 }
 @media (min-width: 1024px) {
   .gho-section-index__title {
-    font-size: 2.5rem;
-    line-height: 2.625rem;
+    font-size: 3.75rem;
+    line-height: 3.25rem;
   }
 }
+
+.gho-section-index__caption {
+  text-align: center;
+  margin-top: 2.25rem;
+  padding-bottom: 2.25rem;
+  border-bottom: 1px solid #d8d8d8;
+}
+.gho-section-index__caption > .gho-caption > * {
+  max-width: none;
+}
+
+
 .gho-section-index__description {
-  margin-top: 2rem;
+  margin-top: 4.5rem;
   font-size: 1rem;
   line-height: 1.75rem;
 }
@@ -62,15 +79,4 @@
 .gho-section-index__description p:last-child {
   margin-bottom: 0;
 }
-.gho-section-index .gho-related-articles {
-  margin-top: 2.25rem;
-  padding-top: 0;
-}
-/* Extra content. */
-.gho-section-index .paragraph {
-  max-width: none;
-  margin-top: 2.25rem;
-}
-.gho-section-index .gho-photo-gallery--single-column .gho-photo-gallery__photos {
-  max-width: none;
-}
+

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-caption--section-index.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-caption--section-index.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-image--section-index.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-image--section-index.html.twig
@@ -1,0 +1,6 @@
+{{ attach_library('common_design_subtheme/gho-hero-image') }}
+<div class="gho-hero-image">
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}
+</div>

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-links--article-list.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-links--article-list.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--home-page.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--home-page.html.twig
@@ -112,14 +112,14 @@
     content in the language of the homepage is enabled.
   #}
   {% if node.isPromoted() %}
-  <div{{ content_attributes.addClass('node__content').addClass('gho-home-page__content').addClass('content-width') }}>
+  <div{{ content_attributes.addClass('node__content').addClass('gho-home-page__content') }}>
     {{ content.field_caption }}
 
     {#
       @todo review alt tag and/or hiding that from the accessibility tree as
       there is already the title above in the header.
     #}
-    <div class="gho-home-page__logo">
+    <div class="gho-home-page__logo content-width">
       <img src="{{ logo }}" alt="{{ 'Global Humanitarian Overview 2021 - Large logo'|t }}">
     </div>
 

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-list.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-list.html.twig
@@ -1,0 +1,64 @@
+{#
+/**
+ * @file
+ * Theme implementation for an article list paragraph.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.a
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-article-list') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-article-list',
+    'content-width',
+  ]
+%}
+{% set title = content.field_title|render %}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {% if title %}
+      <h3 class="gho-article-list__title">{{ title }}</h3>
+      {% endif %}
+      {{ content|without('field_title') }}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--section-index.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--section-index.html.twig
@@ -54,14 +54,20 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-      <header class="gho-section-index__header content-width">
+      <header class="gho-section-index__header">
+        {{ content.field_image }}
         {% if pre_title %}
-        <span class="gho-section-index__pre-title">{{ pre_title }}</span>
-        {% endif %}
-        <h2 class="gho-section-index__title">{{- content.field_title -}}</h2>
+        <div class="gho-section-index__heading">
+          <span class="gho-section-index__pre-title">{{ pre_title }}</span>
+          {% endif %}
+          <h2 class="gho-section-index__title">{{- content.field_title -}}</h2>
+        </div>
       </header>
+      <div class="gho-section-index__caption">
+        {{ content.field_caption }}
+      </div>
       <div class="gho-section-index__content content-width">
-      {{ content|without(['field_section', 'field_title']) }}
+        {{ content|without(['field_image', 'field_section', 'field_title', 'field_caption']) }}
       </div>
     {% endblock %}
   </div>


### PR DESCRIPTION
Ticket: GHO-167

This adds an "article list" paragraph type for the links in a section index with an optional title and a list of internal links. There is a new formatter to be able to get the node titles for the links.

Section index paragraph types are modified with an image field, a caption (location + text) like articles and can now only have "article list" paragraphs.

Styling is changed to match what is in the new PDF.

**Note**: the margins are too big in my opinion on smaller screens but no values were provided so....

## Testing

`Drush cim`, `drush cr` (possible a few times) then edit the homepage, and fill the section index paragraphs.