### PR TITLE
[GHO-170] Override the media oembed resource fetcher to handle youtube quirks

### DIFF
--- a/html/modules/custom/gho_general/src/GhoGeneralServiceProvider.php
+++ b/html/modules/custom/gho_general/src/GhoGeneralServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\gho_general;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Overrides the default media resource fetcher service.
+ */
+class GhoGeneralServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    $definition = $container->getDefinition('media.oembed.resource_fetcher');
+    $definition->setClass('Drupal\gho_general\OEmbed\GhoResourceFetcher');
+  }
+
+}

--- a/html/modules/custom/gho_general/src/OEmbed/GhoResourceFetcher.php
+++ b/html/modules/custom/gho_general/src/OEmbed/GhoResourceFetcher.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\gho_general\OEmbed;
+
+use Drupal\Component\Serialization\Json;
+use GuzzleHttp\Exception\RequestException;
+use Drupal\media\OEmbed\ResourceFetcher;
+
+/**
+ * Fetches and caches oEmbed resources.
+ */
+class GhoResourceFetcher extends ResourceFetcher {
+
+  /**
+   * {@inheritdoc}
+   *
+   * Same code as Drupal\media\OEmbed\ResourceFetcher::fetchResource() with the
+   * added handling of youtube responses with a text/html content type and check
+   * on the decoded data.
+   */
+  public function fetchResource($url) {
+    $cache_id = "media:oembed_resource:$url";
+
+    $cached = $this->cacheGet($cache_id);
+    if ($cached) {
+      return $this->createResource($cached->data, $url);
+    }
+
+    try {
+      $response = $this->httpClient->get($url);
+    }
+    catch (RequestException $e) {
+      throw new ResourceException('Could not retrieve the oEmbed resource.', $url, [], $e);
+    }
+
+    list($format) = $response->getHeader('Content-Type');
+    $content = (string) $response->getBody();
+
+    if (strstr($format, 'text/xml') || strstr($format, 'application/xml')) {
+      $data = $this->parseResourceXml($content, $url);
+    }
+    elseif (strstr($format, 'text/javascript') || strstr($format, 'application/json')) {
+      $data = Json::decode($content);
+    }
+    // Sometimes the youtube oembed proxy returns the wrong content-type while
+    // the body is the correct JSON.
+    elseif (strstr($format, 'text/html') && strpos($url, 'youtube') !== FALSE) {
+      $data = Json::decode($content);
+    }
+    // If the response is neither XML nor JSON, we are in bat country.
+    else {
+      throw new ResourceException('The fetched resource did not have a valid Content-Type header.', $url);
+    }
+
+    // Ensure we have at least a semblance of correct data before caching it.
+    // Json::decode() doesn't throw an exception when failing to parse the data.
+    // ResourceFetcher::createResource() will do additional checks later.
+    if (!is_array($data)) {
+      throw new ResourceException('The fetched resource could not be parsed.', $url);
+    }
+
+    $this->cacheSet($cache_id, $data);
+
+    return $this->createResource($data, $url);
+  }
+
+}


### PR DESCRIPTION
Ticket: GHO-170

It happens that the issue with the youtube videos is due to the youtube oembed proxy that doesn't always return the correct content-type header: `application/json` and sometimes wrongly `text/html` while the response body is a json string with the embed data.

So this overrides the media oembed resource fetcher service to deal with that quirk.

## Testing

`drush cr`.

@rupl This cannot be really tested aside of making sure the videos still appear, so you'll have to trust me on this and just check I didn't typo-ed anything in the code ;-)