### PR TITLE
[GHO-29] Article PDF download

### DIFF
--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
     - field.field.node.article.field_report_link
     - field.field.node.article.field_section
     - field.field.node.article.field_summary
@@ -16,9 +17,9 @@ dependencies:
   module:
     - allowed_formats
     - double_field
+    - file
     - inline_entity_form
     - layout_paragraphs
-    - link
     - media_library
     - path
     - text
@@ -93,13 +94,12 @@ content:
     third_party_settings: {  }
     type: layout_paragraphs
     region: content
-  field_report_link:
+  field_pdf:
     weight: 4
     settings:
-      placeholder_url: 'Ex: https://reliefweb.int/gho-2020.pdf'
-      placeholder_title: ''
+      progress_indicator: throbber
     third_party_settings: {  }
-    type: link_default
+    type: file_generic
     region: content
   field_section:
     weight: 0
@@ -148,6 +148,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_report_link: true
   langcode: true
   promote: true
   sticky: true

--- a/config/core.entity_form_display.node.article.home_page.yml
+++ b/config/core.entity_form_display.node.article.home_page.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
     - field.field.node.article.field_report_link
     - field.field.node.article.field_section
     - field.field.node.article.field_summary
@@ -120,6 +121,7 @@ hidden:
   created: true
   field_appeals: true
   field_author: true
+  field_pdf: true
   field_thumbnail_image: true
   langcode: true
   path: true

--- a/config/core.entity_view_display.node.article.default.yml
+++ b/config/core.entity_view_display.node.article.default.yml
@@ -8,16 +8,15 @@ dependencies:
     - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
     - field.field.node.article.field_report_link
     - field.field.node.article.field_section
     - field.field.node.article.field_summary
     - field.field.node.article.field_thumbnail_image
     - node.type.article
   module:
-    - entity_reference_revisions
     - gho_fields
     - layout_paragraphs
-    - link
     - user
 id: node.article.default
 targetEntityType: node
@@ -67,18 +66,6 @@ content:
     third_party_settings: {  }
     type: layout_paragraphs
     region: content
-  field_report_link:
-    type: link
-    weight: 7
-    region: content
-    label: hidden
-    settings:
-      trim_length: null
-      url_only: false
-      url_plain: false
-      rel: '0'
-      target: '0'
-    third_party_settings: {  }
   field_section:
     weight: 1
     label: hidden
@@ -93,6 +80,8 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_pdf: true
+  field_report_link: true
   field_summary: true
   field_thumbnail_image: true
   langcode: true

--- a/config/core.entity_view_display.node.article.home_page.yml
+++ b/config/core.entity_view_display.node.article.home_page.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
     - field.field.node.article.field_report_link
     - field.field.node.article.field_section
     - field.field.node.article.field_summary
@@ -82,6 +83,7 @@ content:
 hidden:
   field_appeals: true
   field_author: true
+  field_pdf: true
   field_section: true
   field_thumbnail_image: true
   langcode: true

--- a/config/core.entity_view_display.node.article.preview.yml
+++ b/config/core.entity_view_display.node.article.preview.yml
@@ -6,8 +6,10 @@ dependencies:
     - core.entity_view_mode.node.preview
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
+    - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
     - field.field.node.article.field_report_link
     - field.field.node.article.field_section
     - field.field.node.article.field_summary
@@ -64,6 +66,7 @@ content:
     region: content
 hidden:
   field_caption: true
+  field_pdf: true
   field_report_link: true
   field_section: true
   field_summary: true

--- a/config/core.entity_view_display.node.article.related_article.yml
+++ b/config/core.entity_view_display.node.article.related_article.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
     - field.field.node.article.field_report_link
     - field.field.node.article.field_section
     - field.field.node.article.field_summary
@@ -49,6 +50,7 @@ hidden:
   field_caption: true
   field_hero_image: true
   field_paragraphs: true
+  field_pdf: true
   field_report_link: true
   field_section: true
   langcode: true

--- a/config/core.entity_view_display.node.article.sub_article.yml
+++ b/config/core.entity_view_display.node.article.sub_article.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
     - field.field.node.article.field_report_link
     - field.field.node.article.field_section
     - field.field.node.article.field_summary
@@ -72,6 +73,7 @@ content:
     type: layout_paragraphs
     region: content
 hidden:
+  field_pdf: true
   field_report_link: true
   field_section: true
   field_summary: true

--- a/config/core.entity_view_display.node.article.teaser.yml
+++ b/config/core.entity_view_display.node.article.teaser.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.node.article.field_caption
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
     - field.field.node.article.field_report_link
     - field.field.node.article.field_section
     - field.field.node.article.field_summary
@@ -44,6 +45,7 @@ hidden:
   field_caption: true
   field_hero_image: true
   field_paragraphs: true
+  field_pdf: true
   field_report_link: true
   field_section: true
   langcode: true

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -21,6 +21,7 @@ module:
   file: 0
   filter: 0
   gho_access: 0
+  gho_download: 0
   gho_fields: 0
   gho_figures: 0
   gho_footnotes: 0

--- a/config/field.field.node.article.field_pdf.yml
+++ b/config/field.field.node.article.field_pdf.yml
@@ -1,0 +1,27 @@
+uuid: bd8fcfb9-a21f-48dc-a837-c51fbf197475
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_pdf
+    - node.type.article
+  module:
+    - file
+id: node.article.field_pdf
+field_name: field_pdf
+entity_type: node
+bundle: article
+label: PDF
+description: 'PDF version of the article.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: articles
+  file_extensions: pdf
+  max_filesize: ''
+  description_field: false
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/config/field.storage.node.field_pdf.yml
+++ b/config/field.storage.node.field_pdf.yml
@@ -1,0 +1,23 @@
+uuid: 66698d92-8c9c-4d36-9a6a-74512c8fecb1
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_pdf
+field_name: field_pdf
+entity_type: node
+type: file
+settings:
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/user.role.anonymous.yml
+++ b/config/user.role.anonymous.yml
@@ -10,6 +10,7 @@ weight: -10
 is_admin: false
 permissions:
   - 'access content'
+  - 'download article'
   - 'view media'
   - 'view own unpublished media'
   - 'view published achievement content'

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -12,6 +12,7 @@ permissions:
   - 'access content'
   - 'cancel account'
   - 'change own username'
+  - 'download article'
   - 'use text format footnotes'
   - 'use text format limited_html'
   - 'view media'

--- a/html/modules/custom/gho_download/README.md
+++ b/html/modules/custom/gho_download/README.md
@@ -1,0 +1,15 @@
+Global Humanitarian Overview - Download module
+==============================================
+
+This module provides a route to have permanent download URLs for the PDF version
+of an article: https://gho.unocha.org/node/NODEID/download.
+
+Drupal being what it is, the original filename is not saved... so unfortunately
+the filename when saving the above url may have the `_X` suffix. [0]
+
+It's also not possible to have drupal rename the file to preserve its URL. [1]
+
+- [0] https://www.drupal.org/project/drupal/issues/3032376
+- [1] https://www.drupal.org/project/drupal/issues/2648816
+
+This is inspired from https://www.drupal.org/project/media_entity_download

--- a/html/modules/custom/gho_download/gho_download.info.yml
+++ b/html/modules/custom/gho_download/gho_download.info.yml
@@ -1,0 +1,8 @@
+type: module
+name: GHO Download
+description: 'Provides a way to download a PDF version of an article.'
+package: gho
+core_version_requirement: ^8.9 || ^9
+dependencies:
+  - drupal:node
+

--- a/html/modules/custom/gho_download/gho_download.permissions.yml
+++ b/html/modules/custom/gho_download/gho_download.permissions.yml
@@ -1,0 +1,3 @@
+download article:
+  title: 'Download article'
+  description: 'Download the PDF version of an article'

--- a/html/modules/custom/gho_download/gho_download.routing.yml
+++ b/html/modules/custom/gho_download/gho_download.routing.yml
@@ -1,0 +1,8 @@
+gho_download.download:
+  path: '/node/{node}/download'
+  defaults:
+    _controller: '\Drupal\gho_download\Controller\GhoDownloadController::download'
+    _title: 'Download Article'
+  requirements:
+    _permission: 'download article'
+    _entity_access: node.view

--- a/html/modules/custom/gho_download/src/Controller/GhoDownloadController.php
+++ b/html/modules/custom/gho_download/src/Controller/GhoDownloadController.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Drupal\gho_download\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Http\Exception\CacheableNotFoundHttpException;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+/**
+ * Implementation of the GhoDownloadController class.
+ */
+class GhoDownloadController extends ControllerBase {
+
+  /**
+   * Symfony\Component\HttpFoundation\RequestStack definition.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * File system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * The stream wrapper manager.
+   *
+   * @var \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface
+   */
+  protected $streamWrapperManager;
+
+  /**
+   * DownloadController constructor.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request object.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
+   * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager
+   *   The stream wrapper manager.
+   */
+  public function __construct(RequestStack $request_stack, FileSystemInterface $file_system, StreamWrapperManagerInterface $stream_wrapper_manager) {
+    $this->requestStack = $request_stack;
+    $this->fileSystem = $file_system;
+    $this->streamWrapperManager = $stream_wrapper_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('request_stack'),
+      $container->get('file_system'),
+      $container->get('stream_wrapper_manager')
+    );
+  }
+
+  /**
+   * Serves the file upon request.
+   *
+   * For better UX, we throw a page not found instead of a 403 but we make sure
+   * the response can be invalidated when the node, permissions etc. change.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   A valid node object.
+   *
+   * @return \Symfony\Component\HttpFoundation\BinaryFileResponse
+   *   Serve the file as the response.
+   *
+   * @todo throw a page not found for English links?
+   *
+   * @throws \Drupal\Core\Http\Exception\CacheableNotFoundHttpException
+   */
+  public function download(NodeInterface $node) {
+    // Check that the node is an article and has the proper field.
+    if ($node->bundle() !== 'article' || !$node->hasField('field_pdf')) {
+      throw new CacheableNotFoundHttpException($node);
+    }
+
+    // Load the file.
+    $fid = $node->field_pdf->target_id;
+    if (empty($fid)) {
+      throw new CacheableNotFoundHttpException($node);
+    }
+    $file = $this->entityTypeManager()->getStorage('file')->load($fid);
+    if (empty($file)) {
+      throw new CacheableNotFoundHttpException($node);
+    }
+
+    // Check if the file exists.
+    $uri = $file->getFileUri();
+    $filename = $file->getFilename();
+    $scheme = $this->streamWrapperManager->getScheme($uri);
+    if (!$this->streamWrapperManager->isValidScheme($scheme) || !file_exists($uri)) {
+      throw new CacheableNotFoundHttpException($node);
+    }
+
+    // Let other modules provide headers and controls access to the file.
+    $headers = $this->moduleHandler()->invokeAll('file_download', [$uri]);
+    if (empty($headers) || in_array(-1, $headers)) {
+      throw new CacheableNotFoundHttpException($node);
+    }
+
+    // \Drupal\Core\EventSubscriber\FinishResponseSubscriber::onRespond()
+    // sets response as not cacheable if the Cache-Control header is not
+    // already modified. We pass in FALSE for non-private schemes for the
+    // $public parameter to make sure we don't change the headers.
+    $response = new BinaryFileResponse($uri, Response::HTTP_OK, $headers, $scheme !== 'private');
+    if (empty($headers['Content-Disposition'])) {
+      $response->setContentDisposition(
+        ResponseHeaderBag::DISPOSITION_INLINE,
+        $filename
+      );
+    }
+
+    return $response;
+  }
+
+}


### PR DESCRIPTION
Ticket: GHO-29

This is the first part of GHO-29 to create upload PDFs to articles and have a download URL. Next PR will integrate that with the work on GHO-7.

This provides a route to have permanent download URLs for the PDF version of an article: https://gho.unocha.org/node/NODEID/download.

Drupal being what it is, the original filename is not saved... so unfortunately the filename when saving the above url may have the `_X` suffix. [0]

It's also not possible to have drupal rename the file to preserve its URL. [1]

- [0] https://www.drupal.org/project/drupal/issues/3032376
- [1] https://www.drupal.org/project/drupal/issues/2648816

This is inspired from https://www.drupal.org/project/media_entity_download


## Testing

`drush cim`, `drush cr` then add a file to an article and access it via `/node/NODEID/download`.