### PR TITLE
[GHO-186] translate Needs and Requirements label

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/fields/field--taxonomy-term--needs-and-requirements.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--taxonomy-term--needs-and-requirements.html.twig
@@ -47,7 +47,7 @@
   {% if field_name == 'field_requirements' %}
     {% trans %}Requirements <small>(US$)</small>{% endtrans %}
   {% else %}
-    {{ label }}
+    {{ label|t }}
   {% endif %}
   </div>
   {% for item in items %}


### PR DESCRIPTION
This branch was supposed to have the PO files in it, but after doing all the data entry and exporting them, the diff was way bigger than I expected and my local DB seems to have lost a whole lot of translations for other things. I briefly reviewed them and they _seem_ to be admin-facing but it was a huge list and I didn't want to review individual strings.

I will re-do the data entry on prod for the strings that exist and in the mean time let's get this Needs and Requirements string translated for the deploy.