### PR TITLE
[GHO-189] Add permission for editors to select paragraph behavior

### DIFF
--- a/config/user.role.administrator.yml
+++ b/config/user.role.administrator.yml
@@ -56,6 +56,7 @@ permissions:
   - 'edit any achievement content'
   - 'edit any article content'
   - 'edit any story content'
+  - 'edit behavior plugin settings'
   - 'edit own achievement content'
   - 'edit own article content'
   - 'edit own story content'


### PR DESCRIPTION
Ticket: GHO-189

This adds the missing permission to allow editors (Admins) to select a paragraph's behavior. It's only useful for the "bottom figures" to select their appearance (like Top figures or like bottom figures).