### PR TITLE
[GHO-190] Update main menu templates to be compatible with latest version of CD base theme

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/block/block--gho-main-menu.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/block/block--gho-main-menu.html.twig
@@ -36,7 +36,7 @@
     'block',
     'block-menu',
     'navigation',
-    'menu--' ~ derivative_plugin_id|clean_class,
+    'menu--main',
     'cd-nav',
     'cd-site-header__nav',
   ]

--- a/html/themes/custom/common_design_subtheme/templates/navigation/menu--main.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/navigation/menu--main.html.twig
@@ -25,12 +25,18 @@
   @see http://twig.sensiolabs.org/doc/tags/macro.html
 #}
 {{ menus.menu_links(items, attributes, 0) }}
-
 {% macro menu_links(items, attributes, menu_level) %}
   {% import _self as menus %}
   {% if items %}
 
-    <ul{{ attributes.addClass('menu') }}>
+    {%
+      set menu_classes = [
+        'menu',
+        menu_level > 0 ? 'cd-main-menu__dropdown',
+      ]
+    %}
+
+    <ul{{ attributes.addClass(menu_classes) }}>
 
     {% for item in items %}
       {%
@@ -42,34 +48,41 @@
         ]
       %}
 
-      {% if item.is_expanded %}
+      {% set title = item.title == '%username%' ? username : item.title %}
+      {% set id = ('cd-main-menu-item-' ~ menu_level ~ '-' ~ loop.index)|clean_id %}
 
-        {% if item.below %}
+      <li{{ item.attributes.addClass(classes) }}>
 
-          <li{{ item.attributes.addClass(classes) }}>
+        {#
+          Progressive enhancement: make sure there is always a menu entry.
+          If the menu item has children and javascript is enabled then this will
+          be replaced with a button to show the child menu.
+        #}
+        {% if item.url %}
+        <a href="{{ item.url }}" id="{{ id }}"><span>{{ title }}</span></a>
+        {% else %}
+        <span id="{{ id }}">{{ title }}</span>
+        {% endif %}
 
-              <button{{ attributes.addAttribute('data-cd-toggable', 'true') }}>
-                <span class="cd-main-menu__btn-label">{{ item.title }}</span>
-                <svg class="cd-icon cd-icon--arrow-down" width="16" height="16" aria-hidden="true" focusable="false">
-                  <use xlink:href="#cd-icon--arrow-down"></use>
-                </svg>
-              </button>
+        {# If the menu item has children then we mark it as toggable and we'll
+           let the dropdown javascript handle the rest. #}
+        {% if item.is_expanded and item.below %}
 
-              {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+          {%
+            set attributes =  create_attribute({
+              'data-cd-toggable': item.title,
+              'data-cd-icon': 'arrow-down',
+              'data-cd-component': 'cd-main-menu',
+              'data-cd-replace': id,
+              'id': ('cd-main-menu-' ~ menu_level ~ '-' ~ loop.index)|clean_id,
+            })
+          %}
 
-          </li>
+          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
 
         {% endif %}
 
-      {% else %}
-
-          <li{{ item.attributes.addClass(classes) }}>
-
-            <a href="{{ item.url }}"><span>{{ item.title }}</span></a>
-
-          </li>
-
-      {% endif %}
+      </li>
 
     {% endfor %}
     </ul>


### PR DESCRIPTION
Ticket: GHO-190

This makes the templates for the GHO main menu compatible with the latest version of the common design theme.

The changes in the `menu--main.html.twig` should be ported to the common design theme.