### PR TITLE
[GHO-194] Fix language of paragraph preview

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3686,6 +3686,9 @@
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Use proper language when previewing paragraphs in forms": "patches/module--layout-paragraphs--display-proper-language-in-preview.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -7,6 +7,9 @@
         "drupal/entity_usage": {
             "https://www.drupal.org/project/entity_usage/issues/2955078": "https://www.drupal.org/files/issues/2018-04-06/2955078-5.patch"
         },
+        "drupal/layout_paragraphs": {
+          "Use proper language when previewing paragraphs in forms": "patches/module--layout-paragraphs--display-proper-language-in-preview.patch"
+        },
         "drupal/social_auth_hid" : {
             "Optionally allow HID logins during maintenance" : "https://www.drupal.org/files/issues/2020-11-10/3181583-hid-maintenance-logins-2.patch"
         },

--- a/patches/README.md
+++ b/patches/README.md
@@ -14,3 +14,17 @@ Drupal core patches
   https://www.drupal.org/node/2544110
   Prevent protocol stripping on the [datetime](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)
   attribute as it truncates dates like `2020-01-01T:00:00:00` to `00`...
+
+
+Drupal module patches
+---------------------
+
+###  layout_paragraphs
+
+- `module--layout-paragraphs--display-proper-language-in-preview.patch`
+
+  This ensures the proper version of the entity is displayed in the preview
+  when translating: paragraph in the target language if availalble or in the
+  source language otherwise.
+  Related issue: https://www.drupal.org/project/layout_paragraphs/issues/3182031
+  TODO: create new issue on the layout_paragraphs project.

--- a/patches/module--layout-paragraphs--display-proper-language-in-preview.patch
+++ b/patches/module--layout-paragraphs--display-proper-language-in-preview.patch
@@ -1,0 +1,79 @@
+diff --git a/src/Plugin/Field/FieldWidget/LayoutParagraphsWidget.php b/src/Plugin/Field/FieldWidget/LayoutParagraphsWidget.php
+index 55d5af1..38fda4b 100644
+--- a/src/Plugin/Field/FieldWidget/LayoutParagraphsWidget.php
++++ b/src/Plugin/Field/FieldWidget/LayoutParagraphsWidget.php
+@@ -282,11 +282,73 @@ class LayoutParagraphsWidget extends WidgetBase implements ContainerFactoryPlugi
+       : FALSE;
+ 
+     // Build the preview and render it in the form.
++    //
++    // We want to display the preview in the most logical language based on
++    // the target translation language and the source entity. So we determine
++    // which version to use as follows:
++    //
++    // 1. Target language (when creating a new translation).
++    // 2. Source language (when creating a new translation).
++    // 3. Form language (when editing an existing translation).
++    // 4. Entity current language (default).
+     $preview = [];
+     if (isset($entity)) {
++      // Form language.
++      $langcode = $form_state->get('langcode');
++
++      // Current entity language.
++      $entity_langcode = $entity->language()->getId();
++
++      // Retrieve the translation target language.
++      $target_language = $form_state->get(['content_translation', 'target']);
++      $target_langcode = $target_language ? $target_language->getId() : '';
++
++      // Retrieve the translation source language.
++      $source_language = $form_state->get(['content_translation', 'source']);
++      $source_langcode = $source_language ? $source_language->getId() : '';
++
++      // Use the target language for the preview if available. That will be
++      // the case when the form is rebuilt after editing the paragraph.
++      // Ex: /node/{ID}/add/translations/add/es/ar -> Arabic.
++      if (!empty($target_langcode) && $entity->hasTranslation($target_langcode)) {
++        $preview_langcode = $target_langcode;
++      }
++      // If the target language is not available, for example, before editing
++      // the paragraph to create the translation, we try to use the version
++      // corresponding to the source language of the translation, which
++      // should correspond to the language of the host entity.
++      // Ex: /node/{ID}/add/translations/add/es/ar -> Spanish.
++      elseif (!empty($source_langcode) && $entity->hasTranslation($source_langcode)) {
++        $preview_langcode = $source_langcode;
++      }
++      // When editing an existing translation, the language of the form is
++      // the language of the translation if the host entity has a translation
++      // for that language.
++      // Ex: /es/node/{id}/edit -> Spanish.
++      elseif ($entity->hasTranslation($langcode)) {
++        $preview_langcode = $langcode;
++      }
++      // Default to the current version of the entity. That happens when editing
++      // and the host entity doesn't have a translation matching the form
++      // language.
++      // Ex: /fr/node/{id}/edit -> French but host doesn't have such translation
++      // in which case, drupal shows the edit form of the node in its default
++      // language.
++      else {
++        $preview_langcode = $entity_langcode;
++      }
++
++      // Select the entity to use for the preview.
++      if ($preview_langcode !== $entity_langcode && $entity->hasTranslation($preview_langcode)) {
++        $preview_entity = $entity->getTranslation($preview_langcode);
++      }
++      else {
++        $preview_entity = $entity;
++      }
++
+       $preview_view_mode = $this->getSetting('preview_view_mode');
+       $view_builder = $this->entityTypeManager->getViewBuilder($entity->getEntityTypeId());
+-      $preview = $view_builder->view($entity, $preview_view_mode, $entity->language()->getId());
++      $preview = $view_builder->view($preview_entity, $preview_view_mode, $preview_langcode);
+       $preview['#cache']['max-age'] = 0;
+       $preview['#attributes']['class'][] = Html::cleanCssIdentifier($entity->uuid() . '-preview');
+     }


### PR DESCRIPTION
Ticket: GHO-194

This applies a patch to the layout_paragraphs module to display paragraph previews in the proper language based on the translation target and source languages.