### PR TITLE
[CD-270] Save subtheme settings for node title

### DIFF
--- a/config/common_design_subtheme.settings.yml
+++ b/config/common_design_subtheme.settings.yml
@@ -1,0 +1,20 @@
+features:
+  node_user_picture: false
+  comment_user_picture: true
+  comment_user_verification: true
+  favicon: 1
+logo:
+  use_default: 1
+favicon:
+  use_default: 1
+common_design_node_title:
+  full: full
+  home_page: home_page
+  preview: 0
+  related_article: 0
+  rss: 0
+  search_index: 0
+  search_result: 0
+  sub_article: 0
+  teaser: 0
+  token: 0


### PR DESCRIPTION
Ticket: CD-270

This saves the node title settings for the subtheme as the base theme settings are not inherited.

Enables the special handling of the node title for the `home_page` and `full` view modes.