### PR TITLE
GHO-197: translatable alt text for Site Logo

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/block/block--system-branding-block.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/block/block--system-branding-block.html.twig
@@ -7,5 +7,5 @@
   to this block and we pick an SVG with that variable included.
 #}
 <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home" class="cd-site-logo">
-  <img src="{{ site_logo }}{{ language|upper }}.svg" alt="{{ site_name }}" aria-label="{{ 'Home'|t }}"/>
+  <img src="{{ site_logo }}{{ language|upper }}.svg" alt="{{ site_name|t }}" aria-label="{{ 'Home'|t }}"/>
 </a>


### PR DESCRIPTION
# GHO-197

Template update to allow site name to be translated, which is used as alt text in our site logo. The logo itself already renders in each supported language.

## Testing

⚠️ Seeing the translated text may depend on entering content on the "Interface Translation" config screen: https://gho.test/admin/config/regional/translate

Look for the alt text on a non-english page of the website, such as https://gho.test/fr

<img width="547" alt="GHO-197-expected" src="https://user-images.githubusercontent.com/254753/115556329-dd8ed000-a2b0-11eb-8637-d7ff0ee40602.png">
