### PR TITLE
GHO-226: Article Card List summaries

### DIFF
--- a/config/core.entity_view_display.node.article.teaser_card.yml
+++ b/config/core.entity_view_display.node.article.teaser_card.yml
@@ -48,12 +48,11 @@ content:
     type: entity_reference_label
     region: content
   field_summary:
-    type: text_trimmed
+    type: text_default
     weight: 2
     region: content
     label: hidden
-    settings:
-      trim_length: 220
+    settings: {  }
     third_party_settings: {  }
 hidden:
   field_appeals: true

--- a/html/themes/custom/common_design_admin_subtheme/css/styles.css
+++ b/html/themes/custom/common_design_admin_subtheme/css/styles.css
@@ -171,6 +171,18 @@
 }
 
 /*------------------------------------------------------------------------------
+ * Styling of the Article Card List
+ *----------------------------------------------------------------------------*/
+.paragraph--type--article-card-list .field--name-field-articles {
+  display: flex;
+  flex-flow: row wrap;
+  gap: 1rem;
+}
+.paragraph--type--article-card-list .field--name-field-articles .field__item {
+  flex: 0 0 calc((100% / 3) - 2rem);
+}
+
+/*------------------------------------------------------------------------------
  * Editorial indication for unpublished/untranslated entities.
  *----------------------------------------------------------------------------*/
 .node--unpublished {
@@ -187,4 +199,3 @@
 .user-logged-in [class*='--unpublished'][class*='--untranslated'] {
   outline: 4px solid #c30;
 }
-

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
@@ -63,7 +63,7 @@
 }
 
 /* Article title */
-.gho-article-card .gho-article-card__title {
+.gho-article-card__title {
   margin: 1em 0;
   padding: 0 1rem;
   color: var(--cd-black);
@@ -72,7 +72,7 @@
 }
 
 /* Text summary */
-.gho-article-card .field--name-field-summary {
+.gho-article-card__summary {
   margin: 1rem 0;
   padding: 0 1rem;
 }

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
@@ -89,12 +89,14 @@
     'clearfix',
   ]
 %}
+{% set text = content.field_summary|render|striptags %}
+{% set summary_trimmed = text|length > 120 ? text|slice(0, 121)|split(' ')|slice(0, -1)|join(' ') ~ '…' : text %}
 <article{{ attributes.addClass(classes) }}>
   <div{{ content_attributes.addClass('node__content').addClass('gho-article-card__content') }}>
     {{ content.field_hero_image }}
     {{ content.field_section }}
     <h3 class="gho-article-card__title">{{ node.getTitle }}</h3>
-    {{ content.field_summary }}
+    <p class="gho-article-card__summary">{{ summary_trimmed }}</p>
     <a href="{{ url }}" class="gho-article-card__link" title="{{ 'Read this article'|t }}">{{ 'Read this article'|t }}</a>
   </div>
 </article>


### PR DESCRIPTION
# GHO-226

We're trying to enforce consistent styling of the Card Lists across websites, and the 2022 site uses a limit of 120 characters. When I sat down to implement this, I thought it would be a matter of changing a number in the appropriate View Mode, but I ran into issues with the behavior. Specifically, under the trim setting it says:

> If the summary is not set, the trimmed Summary field will end at the last full sentence before this character limit.

In practice I found this to mean the summaries had wildly different lengths based on whether a sentence ended within that 120-char window. My solution was to "un-trim" the summary coming out of the View Mode and do it directly in the Twig template.

So you get pretty darn consistent summary sizes, but it also is aware enough to skip the treatment for short summaries. See screenshot:

<img width="973" alt="Screen Shot 2021-11-12 at 15 18 44" src="https://user-images.githubusercontent.com/254753/141482862-1f495458-53f1-4878-9061-6df96150d54a.png">

