### PR TITLE
GHO-231: CSS tweaks to Heading/Text pairs on Homepage

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-heading/gho-heading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-heading/gho-heading.css
@@ -25,8 +25,9 @@
 
 .gho-heading__pre-title {
   display: block;
-  color: var(--cd-grey--mid);
-  font-size: var(--cd-font-size--small);
+  margin-bottom: 0.5rem;
+  color: #707070;
+  font-size: var(--cd-font-size--tiny);
   font-weight: 700;
   text-transform: uppercase;
 }
@@ -34,7 +35,7 @@
 .gho-heading__title {
   display: block;
   margin: 0;
-  font-size: var(--cd-font-size--2xlarge);
+  font-size: 2.25rem;
   font-weight: 700;
   color: var(--cd-black);
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-home-page/gho-home-page.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-home-page/gho-home-page.css
@@ -200,12 +200,6 @@
   }
 }
 
-@media (min-width: 1024px) {
-  .gho-home-page__content > .gho-text .gho-text__text {
-    font-size: 1.3125rem;
-    line-height: 2.25rem;
-  }
-}
 .gho-home-page__content > .gho-text .gho-text__text p {
   margin: 0;
 }


### PR DESCRIPTION
# GHO-231

Bunch of CSS tweak to Headings/Text paragraphs on the Homepage.

Same as https://github.com/UN-OCHA/gho-2022-site/pull/28